### PR TITLE
refactor: remove default constructor of Result

### DIFF
--- a/src/io/read.h
+++ b/src/io/read.h
@@ -41,10 +41,9 @@ class ReadExt {
     auto next_it = dst.begin();
     auto end_it = next_it + dst_init_size;
     auto dst_size = 0;
-    IoResult<uintptr_t> read_result;
 
     while (true) {
-      read_result =
+      auto read_result =
           (co_await reader.read(next_it, end_it)).map([&](auto nbytes) {
             dst_size += nbytes;
             if (dst_size == dst.size()) {

--- a/tests/sync/mpsc.cc
+++ b/tests/sync/mpsc.cc
@@ -55,7 +55,7 @@ TEST(MpscTest, send_to_full_channel) {
   auto channel_pair = xyco::sync::mpsc::channel<int, 1>();
 
   int value = 0;
-  Result<void, int> send_result;
+  auto send_result = Result<void, int>::ok();
 
   std::thread send([&]() {
     TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {
@@ -83,7 +83,7 @@ TEST(MpscTest, receive_from_empty_channel) {
   auto channel_pair = xyco::sync::mpsc::channel<int, 2>();
 
   int value = 0;
-  Result<void, int> send_result;
+  auto send_result = Result<void, int>::ok();
 
   std::thread receive([&]() {
     TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {

--- a/tests/sync/oneshot.cc
+++ b/tests/sync/oneshot.cc
@@ -65,7 +65,7 @@ TEST(OneshotTest, receive_first) {
   auto channel_pair = xyco::sync::oneshot::channel<int>();
 
   int value = 0;
-  Result<void, int> send_result;
+  auto send_result = Result<void, int>::ok();
 
   std::thread receive([&]() {
     TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {

--- a/tests/utils/result_test.cc
+++ b/tests/utils/result_test.cc
@@ -3,6 +3,17 @@
 #include <gtest/gtest.h>
 
 class ResultTest : public ::testing::Test {
+ public:
+  ResultTest()
+      : no_void_ok_(Result<int, int>::ok(1)),
+        no_void_err_(Result<int, int>::err(1)),
+        void_t_ok_(Result<void, int>::ok()),
+        void_t_err_(Result<void, int>::err(1)),
+        void_e_ok_(Result<int, void>::ok(1)),
+        void_e_err_(Result<int, void>::err()),
+        void_t_void_e_ok_(Result<void, void>::ok()),
+        void_t_void_e_err_(Result<void, void>::err()) {}
+
  protected:
   void SetUp() override {
     no_void_ok_ = Result<int, int>::ok(1);


### PR DESCRIPTION
- use std::monostate to represent empty variant