### PR TITLE
[Test] Improve coverage to fulfill Github check

### DIFF
--- a/src/sync/mpsc.h
+++ b/src/sync/mpsc.h
@@ -202,8 +202,7 @@ class Receiver {
 template <typename Value, size_t Size>
 auto channel() -> std::pair<Sender<Value, Size>, Receiver<Value, Size>> {
   auto shared = std::make_shared<Shared<Value, Size>>();
-  return {Sender<Value, Size>(shared),
-          Receiver<Value, Size>(std::move(shared))};
+  return {Sender<Value, Size>(shared), Receiver<Value, Size>(shared)};
 }
 }  // namespace xyco::sync::mpsc
 

--- a/src/utils/panic.cc
+++ b/src/utils/panic.cc
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <cstdlib>
 #include <sstream>
 #include <vector>
 
@@ -47,7 +48,9 @@ auto addr2line(std::vector<unw_word_t> addresses) -> std::string {
     std::system(cmd.data());
     ::close(STDOUT_FILENO);
     ::close(pipe[1]);
-    std::quick_exit(0);
+    // Uses exit here to flush coverage data.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    std::exit(0);
   } else if (pid > 0) {
     ::close(pipe[1]);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GoogleTest)
 
-set(test_epoll_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/epoll/fmt_test.cc" "utils/fmt_test.cc")
-set(test_uring_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/io_uring/fmt_test.cc" "utils/fmt_test.cc")
+set(test_epoll_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/clock.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/epoll/fmt_test.cc" "utils/fmt_test.cc")
+set(test_uring_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/clock.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/io_uring/fmt_test.cc" "utils/fmt_test.cc")
 
 add_library(common_epoll ${test_epoll_src})
 target_link_libraries(common_epoll fs_epoll io_epoll net_epoll runtime time gtest GSL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GoogleTest)
 
-set(test_epoll_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/epoll/fmt.cc")
-set(test_uring_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/io_uring/fmt.cc")
+set(test_epoll_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/epoll/fmt_test.cc" "utils/fmt_test.cc")
+set(test_uring_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/io_uring/fmt_test.cc" "utils/fmt_test.cc")
 
 add_library(common_epoll ${test_epoll_src})
 target_link_libraries(common_epoll fs_epoll io_epoll net_epoll runtime time gtest GSL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GoogleTest)
 
-set(test_epoll_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/clock.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/epoll/fmt_test.cc" "utils/fmt_test.cc")
-set(test_uring_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/clock.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/io_uring/fmt_test.cc" "utils/fmt_test.cc")
+set(test_epoll_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/runtime.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/clock.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/epoll/fmt_test.cc" "utils/fmt_test.cc")
+set(test_uring_src "common/utils.cc" "fs/file.cc" "io/buffer.cc" "net/socket.cc" "net/tcp.cc" "runtime/future.cc" "runtime/join.cc" "runtime/runtime.cc" "runtime/select.cc" "sync/mpsc.cc" "sync/oneshot.cc" "time/clock.cc" "time/sleep.cc" "time/timeout.cc" "utils/result_test.cc" "utils/io_uring/fmt_test.cc" "utils/fmt_test.cc")
 
 add_library(common_epoll ${test_epoll_src})
 target_link_libraries(common_epoll fs_epoll io_epoll net_epoll runtime time gtest GSL)

--- a/tests/runtime/runtime.cc
+++ b/tests/runtime/runtime.cc
@@ -1,0 +1,133 @@
+#include "utils.h"
+
+class TestLocalRegistry : public xyco::runtime::Registry {
+ public:
+  auto Register(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    event_ = event;
+    return xyco::utils::Result<void>::ok();
+  }
+
+  auto reregister(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return xyco::utils::Result<void>::ok();
+  }
+
+  auto deregister(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return xyco::utils::Result<void>::ok();
+  }
+
+  auto select(xyco::runtime::Events &events, std::chrono::milliseconds timeout)
+      -> xyco::utils::Result<void> override {
+    if (event_) {
+      events.push_back(event_);
+      event_ = nullptr;
+    }
+    return xyco::utils::Result<void>::ok();
+  }
+
+ private:
+  std::shared_ptr<xyco::runtime::Event> event_;
+};
+
+class TestGlobalRegistry : public xyco::runtime::GlobalRegistry {
+ public:
+  auto Register(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return register_local(event);
+  }
+
+  auto reregister(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return reregister_local(event);
+  }
+
+  auto deregister(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return deregister_local(event);
+  }
+
+  auto register_local(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return xyco::runtime::RuntimeCtx::get_ctx()
+        ->driver()
+        .local_handle<TestLocalRegistry>()
+        ->Register(event);
+  }
+
+  auto reregister_local(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return xyco::runtime::RuntimeCtx::get_ctx()
+        ->driver()
+        .local_handle<TestLocalRegistry>()
+        ->reregister(event);
+  }
+
+  auto deregister_local(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override {
+    return xyco::runtime::RuntimeCtx::get_ctx()
+        ->driver()
+        .local_handle<TestLocalRegistry>()
+        ->deregister(event);
+  }
+
+  auto select(xyco::runtime::Events &events, std::chrono::milliseconds timeout)
+      -> xyco::utils::Result<void> override {
+    return xyco::utils::Result<void>::ok();
+  }
+
+  auto local_registry_init() -> void override {
+    xyco::runtime::RuntimeCtx::get_ctx()
+        ->driver()
+        .add_local_registry<TestLocalRegistry>();
+  }
+};
+
+class TestFuture : public xyco::runtime::Future<int> {
+ public:
+  TestFuture()
+      : xyco::runtime::Future<int>(nullptr),
+        event_(std::make_shared<xyco::runtime::Event>(
+            xyco::runtime::Event{.future_ = this})) {}
+
+  auto poll(xyco::runtime::Handle<void> self)
+      -> xyco::runtime::Poll<int> override {
+    if (!registered_) {
+      registered_ = true;
+      xyco::runtime::RuntimeCtx::get_ctx()
+          ->driver()
+          .Register<TestGlobalRegistry>(event_);
+      return xyco::runtime::Pending();
+    }
+    return xyco::runtime::Ready<int>{1};
+  }
+
+ private:
+  bool registered_{};
+  std::shared_ptr<xyco::runtime::Event> event_;
+};
+
+TEST(RuntimeDeathTest, global_registry) {
+  EXPECT_EXIT(
+      {
+        auto runtime = xyco::runtime::Builder::new_multi_thread()
+                           .worker_threads(1)
+                           .max_blocking_threads(1)
+                           .registry<TestGlobalRegistry>()
+                           .build()
+                           .unwrap();
+
+        runtime->spawn([]() -> xyco::runtime::Future<void> {
+          auto result = co_await TestFuture();
+          CO_ASSERT_EQ(result, 1);
+          std::exit(0);
+        }());
+
+        while (true) {
+          // Calls `sleep_for` to avoid while loop being optimized out.
+          std::this_thread::sleep_for(wait_interval);
+        }
+      },
+      testing::ExitedWithCode(0), "");
+}

--- a/tests/sync/mpsc.cc
+++ b/tests/sync/mpsc.cc
@@ -34,7 +34,10 @@ TEST(MpscTest, multi_sender) {
 TEST(MpscTest, receiver_close) {
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto [sender, receiver] = xyco::sync::mpsc::channel<int, 1>();
-    receiver.xyco::sync::mpsc::Receiver<int, 1>::~Receiver();
+    {
+      auto tmp_receiver =
+          std::move(receiver);  // Destructed early to mock receiver closed.
+    }
     auto send_result = co_await sender.send(1);
 
     CO_ASSERT_EQ(send_result.unwrap_err(), 1);
@@ -44,7 +47,10 @@ TEST(MpscTest, receiver_close) {
 TEST(MpscTest, sender_close) {
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto [sender, receiver] = xyco::sync::mpsc::channel<int, 1>();
-    sender.xyco::sync::mpsc::Sender<int, 1>::~Sender();
+    {
+      auto tmp_sender =
+          std::move(sender);  // Destructed early to mock sender closed.
+    }
     auto receive_result = co_await receiver.receive();
 
     CO_ASSERT_EQ(receive_result.has_value(), false);

--- a/tests/sync/oneshot.cc
+++ b/tests/sync/oneshot.cc
@@ -23,7 +23,10 @@ TEST(OneshotTest, success) {
 TEST(OneshotTest, sender_close) {
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto [sender, receiver] = xyco::sync::oneshot::channel<int>();
-    sender.xyco::sync::oneshot::Sender<int>::~Sender();
+    {
+      auto tmp_sender =
+          std::move(sender);  // Destructed early to mock sender closed.
+    }
     auto value = (co_await receiver.receive());
 
     CO_ASSERT_EQ(value.is_err(), true);
@@ -33,7 +36,10 @@ TEST(OneshotTest, sender_close) {
 TEST(OneshotTest, receiver_close) {
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto [sender, receiver] = xyco::sync::oneshot::channel<int>();
-    receiver.xyco::sync::oneshot::Receiver<int>::~Receiver();
+    {
+      auto tmp_receiver =
+          std::move(receiver);  // Destructed early to mock receiver closed.
+    }
     auto send_result = co_await sender.send(1);
 
     CO_ASSERT_EQ(send_result.unwrap_err(), 1);

--- a/tests/time/clock.cc
+++ b/tests/time/clock.cc
@@ -1,0 +1,58 @@
+#include "time/clock.h"
+
+#include <gtest/gtest.h>
+
+// Uses death test here to ensure they run before other time related unit tests
+// to avoid disordering the current time point.
+
+TEST(ClockDeathTest, system_clock) {
+  EXPECT_EXIT(
+      {
+        xyco::time::Clock::init<std::chrono::system_clock>();
+        auto now = xyco::time::Clock::now();
+        auto sys_now = std::chrono::system_clock::now();
+        auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(
+            sys_now - now);
+
+        ASSERT_EQ(gap.count(), 0);
+
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "");
+}
+
+TEST(ClockDeathTest, steady_clock) {
+  EXPECT_EXIT(
+      {
+        xyco::time::Clock::init<std::chrono::steady_clock>();
+        auto now = xyco::time::Clock::now();
+        auto steady_now = std::chrono::steady_clock::now();
+        auto sys_now = std::chrono::system_clock::now();
+        auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(
+            steady_now -
+            std::chrono::time_point_cast<std::chrono::steady_clock::duration>(
+                now - sys_now + steady_now));
+
+        ASSERT_EQ(gap.count(), 0);
+
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "");
+}
+
+TEST(ClockDeathTest, frozen_clock) {
+  EXPECT_EXIT(
+      {
+        xyco::time::Clock::init<xyco::time::FrozenClock>();
+        auto now = xyco::time::Clock::now();
+        xyco::time::FrozenClock::advance(std::chrono::milliseconds(1));
+        auto advance_now = xyco::time::Clock::now();
+        auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(
+            advance_now - now);
+
+        ASSERT_EQ(gap.count(), 1);
+
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "");
+}

--- a/tests/utils/epoll/fmt_test.cc
+++ b/tests/utils/epoll/fmt_test.cc
@@ -1,32 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "net/socket.h"
-#include "runtime/blocking.h"
-#include "time/driver.h"
 #include "utils.h"
-
-TEST(FmtTypeTest, IoError) {
-  auto io_error = xyco::utils::Error();
-  io_error.errno_ = EINTR;
-
-  auto fmt_str = fmt::format("{}", io_error);
-
-  ASSERT_EQ(fmt_str, "IoError{errno=4, info=}");
-}
-
-TEST(FmtTypeTest, file_IoError) {
-  auto io_error = xyco::utils::Error();
-  io_error.errno_ = std::__to_underlying(xyco::utils::ErrorKind::Unsupported);
-
-  auto fmt_str = fmt::format("{}", io_error);
-
-  ASSERT_EQ(fmt_str, "IoError{error_kind=Unsupported, info=}");
-
-  io_error.errno_ = std::__to_underlying(xyco::utils::ErrorKind::Uncategorized);
-  fmt_str = fmt::format("{}", io_error);
-
-  ASSERT_EQ(fmt_str, "IoError{error_kind=Uncategorized, info=}");
-}
 
 TEST(FmtTypeTest, IoExtra_Event) {
   auto event =
@@ -81,54 +55,4 @@ TEST(FmtTypeTest, IoExtra_Event) {
   ASSERT_EQ(fmt_str,
             "Event{extra_=IoExtra{state_=[Registered,Error], interest_=Write, "
             "fd_=4}}");
-}
-
-TEST(FmtTypeTest, TimeExtra_Event) {
-  auto event = xyco::runtime::Event{
-      .extra_ = std::make_unique<xyco::time::TimeExtra>(
-          std::chrono::system_clock::time_point(std::chrono::milliseconds(1)))};
-
-  auto fmt_str = fmt::format("{}", event);
-
-  ASSERT_EQ(fmt_str,
-            "Event{extra_=TimeExtra{expire_time_=1970-01-01 00:00:00}}");
-}
-
-TEST(FmtTypeTest, AsyncFutureExtra_Event) {
-  auto event = xyco::runtime::Event{
-      .extra_ = std::make_unique<xyco::runtime::AsyncFutureExtra>([]() {})};
-
-  auto fmt_str = fmt::format("{}", event);
-
-  ASSERT_EQ(fmt_str, "Event{extra_=AsyncFutureExtra{}}");
-}
-
-TEST(FmtTypeTest, SocketAddr_ipv4) {
-  const char *ip = "127.0.0.1";
-  const uint16_t port = 80;
-
-  auto local_http_addr = xyco::net::SocketAddr::new_v4(ip, port);
-
-  auto fmt_str = fmt::format("{}", local_http_addr);
-
-  ASSERT_EQ(fmt_str, "SocketAddr{ip=127.0.0.1,port=80}");
-}
-
-TEST(FmtTypeTest, SocketAddr_ipv6) {
-  const char *ip = "0:0:0:0:0:0:0:1";
-  const uint16_t port = 80;
-
-  auto local_http_addr = xyco::net::SocketAddr::new_v6(ip, port);
-
-  auto fmt_str = fmt::format("{}", local_http_addr);
-
-  ASSERT_EQ(fmt_str, "SocketAddr{ip=::1,port=80}");
-}
-
-TEST(FmtTypeTest, Socket) {
-  auto socket = xyco::net::Socket(-1);
-
-  auto fmt_str = fmt::format("{}", socket);
-
-  ASSERT_EQ(fmt_str, "Socket{fd_=-1}");
 }

--- a/tests/utils/fmt_test.cc
+++ b/tests/utils/fmt_test.cc
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include "net/socket.h"
+#include "runtime/blocking.h"
+#include "time/driver.h"
+#include "utils.h"
+
+TEST(FmtTypeTest, IoError) {
+  auto io_error = xyco::utils::Error();
+  io_error.errno_ = EINTR;
+
+  auto fmt_str = fmt::format("{}", io_error);
+
+  ASSERT_EQ(fmt_str, "IoError{errno=4, info=}");
+}
+
+TEST(FmtTypeTest, file_IoError) {
+  auto io_error = xyco::utils::Error();
+  io_error.errno_ = std::__to_underlying(xyco::utils::ErrorKind::Unsupported);
+
+  auto fmt_str = fmt::format("{}", io_error);
+
+  ASSERT_EQ(fmt_str, "IoError{error_kind=Unsupported, info=}");
+
+  io_error.errno_ = std::__to_underlying(xyco::utils::ErrorKind::Uncategorized);
+  fmt_str = fmt::format("{}", io_error);
+
+  ASSERT_EQ(fmt_str, "IoError{error_kind=Uncategorized, info=}");
+}
+
+TEST(FmtTypeTest, TimeExtra_Event) {
+  auto event = xyco::runtime::Event{
+      .extra_ = std::make_unique<xyco::time::TimeExtra>(
+          std::chrono::system_clock::time_point(std::chrono::milliseconds(1)))};
+
+  auto fmt_str = fmt::format("{}", event);
+
+  ASSERT_EQ(fmt_str,
+            "Event{extra_=TimeExtra{expire_time_=1970-01-01 00:00:00}}");
+}
+
+TEST(FmtTypeTest, AsyncFutureExtra_Event) {
+  auto event = xyco::runtime::Event{
+      .extra_ = std::make_unique<xyco::runtime::AsyncFutureExtra>([]() {})};
+
+  auto fmt_str = fmt::format("{}", event);
+
+  ASSERT_EQ(fmt_str, "Event{extra_=AsyncFutureExtra{}}");
+}
+
+TEST(FmtTypeTest, SocketAddr_ipv4) {
+  const char *ip = "127.0.0.1";
+  const uint16_t port = 80;
+
+  auto local_http_addr = xyco::net::SocketAddr::new_v4(ip, port);
+
+  auto fmt_str = fmt::format("{}", local_http_addr);
+
+  ASSERT_EQ(fmt_str, "SocketAddr{ip=127.0.0.1,port=80}");
+}
+
+TEST(FmtTypeTest, SocketAddr_ipv6) {
+  const char *ip = "0:0:0:0:0:0:0:1";
+  const uint16_t port = 80;
+
+  auto local_http_addr = xyco::net::SocketAddr::new_v6(ip, port);
+
+  auto fmt_str = fmt::format("{}", local_http_addr);
+
+  ASSERT_EQ(fmt_str, "SocketAddr{ip=::1,port=80}");
+}
+
+TEST(FmtTypeTest, Socket) {
+  auto socket = xyco::net::Socket(-1);
+
+  auto fmt_str = fmt::format("{}", socket);
+
+  ASSERT_EQ(fmt_str, "Socket{fd_=-1}");
+}

--- a/tests/utils/io_uring/fmt_test.cc
+++ b/tests/utils/io_uring/fmt_test.cc
@@ -1,32 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "net/socket.h"
-#include "runtime/blocking.h"
-#include "time/driver.h"
 #include "utils.h"
-
-TEST(FmtTypeTest, IoError) {
-  auto io_error = xyco::utils::Error();
-  io_error.errno_ = EINTR;
-
-  auto fmt_str = fmt::format("{}", io_error);
-
-  ASSERT_EQ(fmt_str, "IoError{errno=4, info=}");
-}
-
-TEST(FmtTypeTest, file_IoError) {
-  auto io_error = xyco::utils::Error();
-  io_error.errno_ = std::__to_underlying(xyco::utils::ErrorKind::Unsupported);
-
-  auto fmt_str = fmt::format("{}", io_error);
-
-  ASSERT_EQ(fmt_str, "IoError{error_kind=Unsupported, info=}");
-
-  io_error.errno_ = std::__to_underlying(xyco::utils::ErrorKind::Uncategorized);
-  fmt_str = fmt::format("{}", io_error);
-
-  ASSERT_EQ(fmt_str, "IoError{error_kind=Uncategorized, info=}");
-}
 
 TEST(FmtTypeTest, IoExtra_Event) {
   auto event =
@@ -103,54 +77,4 @@ TEST(FmtTypeTest, IoExtra_Event) {
   ASSERT_EQ(fmt_str,
             "Event{extra_=IoExtra{args_=Shutdown{shutdown_=Shutdown{All}}, "
             "fd_=1, return_=0}}");
-}
-
-TEST(FmtTypeTest, TimeExtra_Event) {
-  auto event = xyco::runtime::Event{
-      .extra_ = std::make_unique<xyco::time::TimeExtra>(
-          std::chrono::system_clock::time_point(std::chrono::milliseconds(1)))};
-
-  auto fmt_str = fmt::format("{}", event);
-
-  ASSERT_EQ(fmt_str,
-            "Event{extra_=TimeExtra{expire_time_=1970-01-01 00:00:00}}");
-}
-
-TEST(FmtTypeTest, AsyncFutureExtra_Event) {
-  auto event = xyco::runtime::Event{
-      .extra_ = std::make_unique<xyco::runtime::AsyncFutureExtra>([]() {})};
-
-  auto fmt_str = fmt::format("{}", event);
-
-  ASSERT_EQ(fmt_str, "Event{extra_=AsyncFutureExtra{}}");
-}
-
-TEST(FmtTypeTest, SocketAddr_ipv4) {
-  const char *ip = "127.0.0.1";
-  const uint16_t port = 80;
-
-  auto local_http_addr = xyco::net::SocketAddr::new_v4(ip, port);
-
-  auto fmt_str = fmt::format("{}", local_http_addr);
-
-  ASSERT_EQ(fmt_str, "SocketAddr{ip=127.0.0.1,port=80}");
-}
-
-TEST(FmtTypeTest, SocketAddr_ipv6) {
-  const char *ip = "0:0:0:0:0:0:0:1";
-  const uint16_t port = 80;
-
-  auto local_http_addr = xyco::net::SocketAddr::new_v6(ip, port);
-
-  auto fmt_str = fmt::format("{}", local_http_addr);
-
-  ASSERT_EQ(fmt_str, "SocketAddr{ip=::1,port=80}");
-}
-
-TEST(FmtTypeTest, Socket) {
-  auto socket = xyco::net::Socket(-1);
-
-  auto fmt_str = fmt::format("{}", socket);
-
-  ASSERT_EQ(fmt_str, "Socket{fd_=-1}");
 }


### PR DESCRIPTION
# Feature
- Union common fmt unit tests.
- Add clock and global registry unit tests to improve test coverage.
- Fix multiprocess coverage missing error.
- Apply a more graceful way to destruct object early in sync unit tests.