### PR TITLE
[Fix] Swallow unhandled exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: test
         run: |
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle
+          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
+          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
           mv $(bazel info bazel-testlogs)/tests/xyco_test_epoll/coverage.dat coverage_epoll.dat && mv $(bazel info bazel-testlogs)/tests/xyco_test_uring/coverage.dat coverage_uring.dat
       - name: upload epoll coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: test
         run: |
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle
+          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
+          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
           mv $(bazel info bazel-testlogs)/tests/xyco_test_epoll/coverage.dat coverage_epoll.dat && mv $(bazel info bazel-testlogs)/tests/xyco_test_uring/coverage.dat coverage_uring.dat
       - name: upload epoll coverage report
         uses: codecov/codecov-action@v3

--- a/tests/runtime/future.cc
+++ b/tests/runtime/future.cc
@@ -110,31 +110,37 @@ TEST(RuntimeDeathTest, terminate) {
           throw std::runtime_error("");
           co_return;
         }());
-        std::this_thread::sleep_for(time_deviation);
+        std::this_thread::sleep_for(2 * time_deviation);
       },
       "");
 }
 
 TEST(RuntimeDeathTest, coroutine_exception) {
-  auto rt = xyco::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .max_blocking_threads(1)
-                .build()
-                .unwrap();
-  rt->spawn([]() -> xyco::runtime::Future<void> {
-    throw std::runtime_error("");
-    co_return;
-  }());
+  EXPECT_EXIT(
+      {
+        auto rt = xyco::runtime::Builder::new_multi_thread()
+                      .worker_threads(2)
+                      .max_blocking_threads(1)
+                      .build()
+                      .unwrap();
+        rt->spawn([]() -> xyco::runtime::Future<void> {
+          throw std::runtime_error("");
+          co_return;
+        }());
 
-  std::atomic_int result = -1;
-  auto fut = [&]() -> xyco::runtime::Future<void> {
-    result = 1;
-    co_return;
-  };
-  rt->spawn(fut());
-  std::this_thread::sleep_for(time_deviation);
+        std::atomic_int result = -1;
+        auto fut = [&]() -> xyco::runtime::Future<void> {
+          result = 1;
+          co_return;
+        };
+        rt->spawn(fut());
+        std::this_thread::sleep_for(time_deviation);
 
-  ASSERT_EQ(result, 1);
+        ASSERT_EQ(result, 1);
+
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "");
 }
 
 class DropAsserter {
@@ -172,19 +178,26 @@ class DropAsserter {
 
 std::atomic_bool DropAsserter::dropped_ = false;
 
-TEST(DropTest, drop_parameter) {
-  auto rt = xyco::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
-                .max_blocking_threads(1)
-                .build()
-                .unwrap();
+TEST(RuntimeDeathTest, drop_parameter) {
+  EXPECT_EXIT(
+      {
+        auto rt = xyco::runtime::Builder::new_multi_thread()
+                      .worker_threads(1)
+                      .max_blocking_threads(1)
+                      .build()
+                      .unwrap();
 
-  auto drop_asserter = DropAsserter(2);
-  rt->spawn([](DropAsserter drop_asserter) -> xyco::runtime::Future<void> {
-    co_return;
-  }(std::move(drop_asserter)));
+        auto drop_asserter = DropAsserter(2);
+        rt->spawn(
+            [](DropAsserter drop_asserter) -> xyco::runtime::Future<void> {
+              co_return;
+            }(std::move(drop_asserter)));
 
-  std::this_thread::sleep_for(time_deviation);
+        std::this_thread::sleep_for(time_deviation);
 
-  DropAsserter::assert_drop();
+        DropAsserter::assert_drop();
+
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "");
 }


### PR DESCRIPTION
# Feature
- Fix error: Coroutines executed without suspending swallow unhandled exception thrown by the awaiting coroutine and suspend forever.
- Put all unit tests with standalone runtime to death tests.