### PR TITLE
[Feat] Add global clock config for time module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ set(net_all_src "net/socket.cc" "net/epoll/listener.cc" "net/io_uring/listener.c
 
 set(runtime_src "runtime/blocking.cc" "runtime/driver.cc" "runtime/future.cc" "runtime/registry.cc" "runtime/runtime.cc")
 
-set(time_src "time/driver.cc" "time/wheel.cc")
+set(time_src "time/driver.cc" "time/wheel.cc" "time/clock.cc")
 
 set(utils_src "utils/error.cc" "utils/panic.cc")
 

--- a/src/time/clock.cc
+++ b/src/time/clock.cc
@@ -1,0 +1,8 @@
+#include "clock.h"
+
+std::variant<std::chrono::system_clock, std::chrono::steady_clock,
+             xyco::time::FrozenClock>
+    xyco::time::Clock::clock_ = std::chrono::system_clock();
+
+xyco::time::FrozenClock::time_point xyco::time::FrozenClock::time_point_ =
+    xyco::time::FrozenClock::time_point::clock::now();

--- a/src/time/clock.h
+++ b/src/time/clock.h
@@ -1,0 +1,66 @@
+#ifndef XYCO_TIME_CLOCK_H
+#define XYCO_TIME_CLOCK_H
+
+#include <chrono>
+#include <variant>
+
+#include "utils/overload.h"
+
+namespace xyco::time {
+template <typename C>
+concept Clockable = requires {
+  { C::now() } -> std::same_as<typename C::time_point>;
+};
+
+class FrozenClock {
+  using time_point = std::chrono::system_clock::time_point;
+
+ public:
+  static auto now() -> time_point { return time_point_; }
+
+  template <typename Rep, typename Ratio>
+  static auto advance(std::chrono::duration<Rep, Ratio> duration) -> void {
+    time_point_ += duration;
+  }
+
+ private:
+  static time_point time_point_;
+};
+
+class Clock {
+ public:
+  static auto now() -> std::chrono::system_clock::time_point {
+    return std::visit(
+        overloaded{
+            [](std::chrono::system_clock clock) {
+              return std::chrono::system_clock::now();
+            },
+            [](FrozenClock clock) { return xyco::time::FrozenClock::now(); },
+            [](auto clock) {
+              auto now = clock.now();
+              return std::chrono::time_point_cast<
+                  std::chrono::system_clock::duration>(
+                  now - clock.now() + std::chrono::system_clock::now());
+            }},
+        clock_);
+  }
+
+  template <typename C>
+  static auto init() -> void requires(Clockable<C>) {
+    if constexpr (std::is_same_v<C, std::chrono::steady_clock>) {
+      clock_ = std::chrono::steady_clock();
+    } else if constexpr (std::is_same_v<C, FrozenClock>) {
+      clock_ = FrozenClock();
+    } else {
+      clock_ = std::chrono::system_clock();
+    }
+  }
+
+ private:
+  static std::variant<std::chrono::system_clock, std::chrono::steady_clock,
+                      FrozenClock>
+      clock_;
+};
+}  // namespace xyco::time
+
+#endif  // XYCO_TIME_CLOCK_H

--- a/src/time/sleep.h
+++ b/src/time/sleep.h
@@ -1,8 +1,7 @@
 #ifndef XYCO_TIME_SLEEP_H
 #define XYCO_TIME_SLEEP_H
 
-#include <chrono>
-
+#include "clock.h"
 #include "runtime/runtime.h"
 #include "time/driver.h"
 
@@ -22,7 +21,7 @@ auto sleep(std::chrono::duration<Rep, Ratio> duration)
       if (!ready_) {
         ready_ = true;
         auto *extra = dynamic_cast<TimeExtra *>(event_->extra_.get());
-        extra->expire_time_ = std::chrono::system_clock::now() + duration_;
+        extra->expire_time_ = Clock::now() + duration_;
         event_->future_ = this;
         runtime::RuntimeCtx::get_ctx()->driver().Register<TimeRegistry>(event_);
 

--- a/src/time/wheel.cc
+++ b/src/time/wheel.cc
@@ -1,5 +1,6 @@
 #include "wheel.h"
 
+#include "time/clock.h"
 #include "time/driver.h"
 
 xyco::time::Level::Level() : current_it_(events_.begin()) {}
@@ -34,20 +35,18 @@ auto xyco::time::Wheel::insert_event(std::weak_ptr<runtime::Event> event)
 }
 
 auto xyco::time::Wheel::expire(runtime::Events &events) -> void {
-  auto now = std::chrono::system_clock::now();
+  auto now = Clock::now();
   if (now > now_) {
     auto steps =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - now_)
             .count() /
         interval_ms_;
-    walk(static_cast<int>(steps), events);
     now_ = now;
+    walk(static_cast<int>(steps), events);
   }
 }
 
-xyco::time::Wheel::Wheel()
-    : now_(std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::system_clock::now().time_since_epoch())) {}
+xyco::time::Wheel::Wheel() : now_(Clock::now()) {}
 
 auto xyco::time::Wheel::walk(int steps, runtime::Events &events) -> void {
   auto level = 0;

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -18,7 +18,7 @@ cc_test(
         "//src/sync",
         "//src/time",
         "//src/utils",
-        "@googletest//:gtest_main",
+        "@googletest//:gtest",
     ],
 )
 
@@ -40,6 +40,6 @@ cc_test(
         "//src/sync",
         "//src/time",
         "//src/utils",
-        "@googletest//:gtest_main",
+        "@googletest//:gtest",
     ],
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,10 +12,8 @@ set(CMAKE_CXX_FLAGS "-fprofile-instr-generate -fcoverage-mapping ${CMAKE_CXX_FLA
 
 include_directories(common)
 
-add_executable(xyco_test_epoll ${test_epoll_src})
-target_link_libraries(xyco_test_epoll common_epoll gtest_main)
+add_executable(xyco_test_epoll ${test_epoll_src} main.cc)
 gtest_discover_tests(xyco_test_epoll)
 
-add_executable(xyco_test_uring ${test_uring_src})
-target_link_libraries(xyco_test_uring common_uring gtest_main)
+add_executable(xyco_test_uring ${test_uring_src} main.cc)
 gtest_discover_tests(xyco_test_uring)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,9 @@ set(CMAKE_CXX_FLAGS "-fprofile-instr-generate -fcoverage-mapping ${CMAKE_CXX_FLA
 include_directories(common)
 
 add_executable(xyco_test_epoll ${test_epoll_src} main.cc)
+target_link_libraries(xyco_test_epoll common_epoll gtest)
 gtest_discover_tests(xyco_test_epoll)
 
 add_executable(xyco_test_uring ${test_uring_src} main.cc)
+target_link_libraries(xyco_test_uring common_uring gtest)
 gtest_discover_tests(xyco_test_uring)

--- a/tests/common/utils.cc
+++ b/tests/common/utils.cc
@@ -3,16 +3,7 @@
 #include "io/registry.h"
 #include "time/driver.h"
 
-std::unique_ptr<xyco::runtime::Runtime> TestRuntimeCtx::runtime_(
-    xyco::runtime::Builder::new_multi_thread()
-        .worker_threads(1)
-        .max_blocking_threads(1)
-        .registry<xyco::io::IoRegistry>(4)
-        .registry<xyco::time::TimeRegistry>()
-        .on_worker_start([]() {})
-        .on_worker_stop([]() {})
-        .build()
-        .unwrap());
+std::unique_ptr<xyco::runtime::Runtime> TestRuntimeCtx::runtime_;
 
 TestRuntimeCtxGuard::TestRuntimeCtxGuard(
     gsl::owner<std::function<xyco::runtime::Future<void>()> *> co_wrapper,
@@ -27,4 +18,16 @@ TestRuntimeCtxGuard::TestRuntimeCtxGuard(
 TestRuntimeCtxGuard::~TestRuntimeCtxGuard() {
   xyco::runtime::RuntimeCtx::set_ctx(nullptr);
   delete co_wrapper_;
+}
+
+auto TestRuntimeCtx::init() -> void {
+  runtime_ = xyco::runtime::Builder::new_multi_thread()
+                 .worker_threads(1)
+                 .max_blocking_threads(1)
+                 .registry<xyco::io::IoRegistry>(4)
+                 .registry<xyco::time::TimeRegistry>()
+                 .on_worker_start([]() {})
+                 .on_worker_stop([]() {})
+                 .build()
+                 .unwrap();
 }

--- a/tests/common/utils.h
+++ b/tests/common/utils.h
@@ -9,6 +9,7 @@
 #include "io/extra.h"
 #include "net/listener.h"
 #include "runtime/runtime.h"
+#include "time/clock.h"
 
 #define CO_ASSERT_EQ(val1, val2)               \
   ({                                           \
@@ -16,7 +17,7 @@
     f();                                       \
   })
 
-constexpr std::chrono::milliseconds time_deviation(7);
+constexpr std::chrono::milliseconds wait_interval(5);
 
 class TestRuntimeCtxGuard {
  public:
@@ -43,7 +44,8 @@ class TestRuntimeCtx {
  public:
   // run until co finished
   template <typename Fn>
-  static auto co_run(Fn &&coroutine)
+  static auto co_run(Fn &&coroutine,
+                     std::vector<std::chrono::milliseconds> &&time_steps = {})
       -> void requires(std::is_invocable_r_v<xyco::runtime::Future<void>, Fn>) {
     // co_outer's lifetime is managed by the caller to avoid being destroyed
     // automatically before resumed.
@@ -54,7 +56,14 @@ class TestRuntimeCtx {
 
     auto co_outer = [&]() -> xyco::runtime::Future<void> {
       try {
+        std::thread t([&]() {
+          for (const auto &step : time_steps) {
+            std::this_thread::sleep_for(clock_interval_);
+            xyco::time::FrozenClock::advance(step);
+          }
+        });
         co_await coroutine();
+        t.join();
         condition_variable.notify_one();
       } catch (std::exception e) {
         [&]() { ASSERT_NO_THROW(throw e); }();
@@ -85,7 +94,14 @@ class TestRuntimeCtx {
     return {co_outer, false};
   }
 
+  static auto init() -> void;
+
  private:
+  // IO syscall in every iteration costs 2ms at most. Some coroutines like
+  // `timeout` have to experience several iterations to reach the pending point.
+  // So assigns a relatively large interval here.
+  static constexpr std::chrono::milliseconds clock_interval_{10};
+
   static std::unique_ptr<xyco::runtime::Runtime> runtime_;
 };
 

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+#include "time/clock.h"
+#include "utils.h"
+
+auto main(int argc, char **argv) -> int {
+  xyco::time::Clock::init<xyco::time::FrozenClock>();
+  TestRuntimeCtx::init();
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/runtime/future.cc
+++ b/tests/runtime/future.cc
@@ -110,7 +110,7 @@ TEST(RuntimeDeathTest, terminate) {
           throw std::runtime_error("");
           co_return;
         }());
-        std::this_thread::sleep_for(2 * time_deviation);
+        std::this_thread::sleep_for(2 * wait_interval);
       },
       "");
 }
@@ -136,7 +136,7 @@ TEST(RuntimeDeathTest, coroutine_exception) {
             co_return;
           };
           rt->spawn(fut());
-          std::this_thread::sleep_for(time_deviation);
+          std::this_thread::sleep_for(wait_interval);
 
           ASSERT_EQ(result, 1);
         }
@@ -196,7 +196,7 @@ TEST(RuntimeDeathTest, drop_parameter) {
                 co_return;
               }(std::move(drop_asserter)));
 
-          std::this_thread::sleep_for(time_deviation);
+          std::this_thread::sleep_for(wait_interval);
 
           DropAsserter::assert_drop();
         }

--- a/tests/sync/mpsc.cc
+++ b/tests/sync/mpsc.cc
@@ -64,7 +64,7 @@ TEST(MpscTest, send_to_full_channel) {
     });
   });
 
-  std::this_thread::sleep_for(time_deviation);  // wait sender pending
+  std::this_thread::sleep_for(wait_interval);  // wait sender pending
 
   std::thread receive([&]() {
     TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {
@@ -91,7 +91,7 @@ TEST(MpscTest, receive_from_empty_channel) {
     });
   });
 
-  std::this_thread::sleep_for(time_deviation);  // wait receive pending
+  std::this_thread::sleep_for(wait_interval);  // wait receive pending
 
   std::thread send([&]() {
     TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {

--- a/tests/sync/oneshot.cc
+++ b/tests/sync/oneshot.cc
@@ -73,7 +73,7 @@ TEST(OneshotTest, receive_first) {
     });
   });
 
-  std::this_thread::sleep_for(time_deviation);  // wait receive pending
+  std::this_thread::sleep_for(wait_interval);  // wait receive pending
 
   std::thread send([&]() {
     TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {

--- a/tests/time/sleep.cc
+++ b/tests/time/sleep.cc
@@ -5,18 +5,21 @@
 #include "utils.h"
 
 TEST(SleepTest, sleep_accuracy) {
-  TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
-    constexpr std::chrono::milliseconds timeout_ms =
-        std::chrono::milliseconds(10);
+  constexpr std::chrono::milliseconds timeout_ms = std::chrono::milliseconds(3);
 
-    auto before_run = std::chrono::system_clock::now();
-    co_await xyco::time::sleep(timeout_ms);
-    auto interval = std::chrono::duration_cast<std::chrono::milliseconds>(
-                        std::chrono::system_clock::now() - before_run)
-                        .count();
+  TestRuntimeCtx::co_run(
+      [&]() -> xyco::runtime::Future<void> {
+        auto before_run = xyco::time::Clock::now();
 
-    CO_ASSERT_EQ(interval >= (timeout_ms - time_deviation).count() &&
-                     interval <= (timeout_ms + time_deviation).count(),
-                 true);
-  });
+        co_await xyco::time::sleep(timeout_ms);
+        auto interval = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            xyco::time::Clock::now() - before_run)
+                            .count();
+
+        CO_ASSERT_EQ(
+            interval >= (timeout_ms - std::chrono::milliseconds(1)).count() &&
+                interval <= (timeout_ms + std::chrono::milliseconds(1)).count(),
+            true);
+      },
+      {timeout_ms + std::chrono::milliseconds(1)});
 }

--- a/tests/time/timeout.cc
+++ b/tests/time/timeout.cc
@@ -5,59 +5,66 @@
 #include "utils.h"
 
 TEST(TimeoutTest, no_timeout) {
-  TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
-    constexpr std::chrono::milliseconds timeout_ms =
-        std::chrono::milliseconds(10);
+  constexpr std::chrono::milliseconds timeout_ms = std::chrono::milliseconds(3);
 
-    auto co_inner = []() -> xyco::runtime::Future<int> { co_return 1; };
+  TestRuntimeCtx::co_run(
+      [&]() -> xyco::runtime::Future<void> {
+        auto co_inner = []() -> xyco::runtime::Future<int> { co_return 1; };
 
-    auto result = co_await xyco::time::timeout(timeout_ms, co_inner());
+        auto result = co_await xyco::time::timeout(timeout_ms, co_inner());
 
-    CO_ASSERT_EQ(result.unwrap(), 1);
-  });
+        CO_ASSERT_EQ(result.unwrap(), 1);
+      },
+      {timeout_ms + std::chrono::milliseconds(1)});
 }
 
 TEST(TimeoutTest, timeout) {
-  TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
-    constexpr std::chrono::milliseconds timeout_ms =
-        std::chrono::milliseconds(10);
+  constexpr std::chrono::milliseconds timeout_ms = std::chrono::milliseconds(3);
 
-    auto co_inner = [&]() -> xyco::runtime::Future<int> {
-      co_await xyco::time::sleep(timeout_ms + time_deviation);
-      co_return 1;
-    };
+  TestRuntimeCtx::co_run(
+      [&]() -> xyco::runtime::Future<void> {
+        auto co_inner = [&]() -> xyco::runtime::Future<int> {
+          co_await xyco::time::sleep(timeout_ms + std::chrono::milliseconds(2));
+          co_return 1;
+        };
 
-    auto result = co_await xyco::time::timeout(timeout_ms, co_inner());
+        auto result = co_await xyco::time::timeout(timeout_ms, co_inner());
 
-    CO_ASSERT_EQ(result.is_err(), true);
-  });
+        CO_ASSERT_EQ(result.is_err(), true);
+      },
+      {timeout_ms + std::chrono::milliseconds(1)});
 }
 
 TEST(TimeoutTest, longer_timeout) {
-  TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
-    constexpr std::chrono::milliseconds timeout_ms =
-        std::chrono::milliseconds(6);
+  constexpr std::chrono::milliseconds timeout_ms =
+      std::chrono::milliseconds(60);
 
-    auto co_inner = [&]() -> xyco::runtime::Future<int> {
-      co_await xyco::time::sleep(10 * timeout_ms);
-      co_return 1;
-    };
+  TestRuntimeCtx::co_run(
+      [&]() -> xyco::runtime::Future<void> {
+        auto co_inner = [&]() -> xyco::runtime::Future<int> {
+          co_await xyco::time::sleep(timeout_ms);
+          co_return 1;
+        };
 
-    auto result = co_await xyco::time::timeout(11 * timeout_ms, co_inner());
+        auto result = co_await xyco::time::timeout(
+            timeout_ms + +std::chrono::milliseconds(2), co_inner());
 
-    CO_ASSERT_EQ(result.is_ok(), true);
-  });
+        CO_ASSERT_EQ(result.is_ok(), true);
+      },
+      {timeout_ms + std::chrono::milliseconds(1),
+       std::chrono::milliseconds(2)});
 }
 
 TEST(TimeoutTest, void_future) {
-  TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
-    constexpr std::chrono::milliseconds timeout_ms =
-        std::chrono::milliseconds(10);
+  constexpr std::chrono::milliseconds timeout_ms = std::chrono::milliseconds(3);
 
-    auto co_inner = []() -> xyco::runtime::Future<void> { co_return; };
+  TestRuntimeCtx::co_run(
+      [&]() -> xyco::runtime::Future<void> {
+        auto co_inner = []() -> xyco::runtime::Future<void> { co_return; };
 
-    auto result = co_await xyco::time::timeout(timeout_ms, co_inner());
+        auto result = co_await xyco::time::timeout(timeout_ms, co_inner());
 
-    CO_ASSERT_EQ(result.is_ok(), true);
-  });
+        CO_ASSERT_EQ(result.is_ok(), true);
+      },
+      {timeout_ms + std::chrono::milliseconds(1)});
 }

--- a/tools/git-hooks/src/pre_commit.rs
+++ b/tools/git-hooks/src/pre_commit.rs
@@ -24,7 +24,7 @@ impl SubCheck {
 }
 
 fn get_source_paths(root_path: PathBuf) -> Vec<PathBuf> {
-    if let Ok(dir) = std::fs::read_dir(&root_path) {
+    if let Ok(dir) = std::fs::read_dir(root_path) {
         return dir
             .filter_map(|entry| {
                 if let Ok(entry) = entry {


### PR DESCRIPTION
# Feature
- Add a clock class in time module to provide the ability to choose clock as needed.
- Apply handy driven frozen clock in unit tests to better control how time related unit tests run.