### PR TITLE
[Refactor] Deprecate custom_flags in fs module

### DIFF
--- a/src/fs/epoll/file.cc
+++ b/src/fs/epoll/file.cc
@@ -211,8 +211,7 @@ auto xyco::fs::epoll::OpenOptions::open(std::filesystem::path&& path)
           [](auto n) { return File(-1, std::filesystem::path()); });
     }
 
-    int flags = O_CLOEXEC | access_mode.unwrap() | creation_mode.unwrap() |
-                (custom_flags_ & O_ACCMODE);
+    int flags = O_CLOEXEC | access_mode.unwrap() | creation_mode.unwrap();
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     return utils::into_sys_result(::open(path.c_str(), flags, mode_))
         .map([&](auto file_descriptor) {
@@ -251,11 +250,6 @@ auto xyco::fs::epoll::OpenOptions::create_new(bool create_new) -> OpenOptions& {
   return *this;
 }
 
-auto xyco::fs::epoll::OpenOptions::custom_flags(int32_t flags) -> OpenOptions& {
-  custom_flags_ = flags;
-  return *this;
-}
-
 auto xyco::fs::epoll::OpenOptions::mode(uint32_t mode) -> OpenOptions& {
   mode_ = mode;
   return *this;
@@ -268,7 +262,6 @@ xyco::fs::epoll::OpenOptions::OpenOptions()
       truncate_(false),
       create_(false),
       create_new_(false),
-      custom_flags_(0),
       mode_(default_mode_) {}
 
 auto xyco::fs::epoll::OpenOptions::get_access_mode() const

--- a/src/fs/epoll/file.h
+++ b/src/fs/epoll/file.h
@@ -101,8 +101,6 @@ class OpenOptions {
 
   auto create_new(bool create_new) -> OpenOptions &;
 
-  auto custom_flags(int32_t flags) -> OpenOptions &;
-
   auto mode(uint32_t mode) -> OpenOptions &;
 
   OpenOptions();
@@ -122,7 +120,6 @@ class OpenOptions {
   bool create_;
   bool create_new_;
   // system-specific
-  int32_t custom_flags_;
   mode_t mode_;
 };
 }  // namespace xyco::fs::epoll

--- a/src/fs/io_uring/file.cc
+++ b/src/fs/io_uring/file.cc
@@ -211,8 +211,7 @@ auto xyco::fs::uring::OpenOptions::open(std::filesystem::path&& path)
           [](auto n) { return File(-1, std::filesystem::path()); });
     }
 
-    int flags = O_CLOEXEC | access_mode.unwrap() | creation_mode.unwrap() |
-                (custom_flags_ & O_ACCMODE);
+    int flags = O_CLOEXEC | access_mode.unwrap() | creation_mode.unwrap();
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     return utils::into_sys_result(::open(path.c_str(), flags, mode_))
         .map([&](auto file_descriptor) {
@@ -251,11 +250,6 @@ auto xyco::fs::uring::OpenOptions::create_new(bool create_new) -> OpenOptions& {
   return *this;
 }
 
-auto xyco::fs::uring::OpenOptions::custom_flags(int32_t flags) -> OpenOptions& {
-  custom_flags_ = flags;
-  return *this;
-}
-
 auto xyco::fs::uring::OpenOptions::mode(uint32_t mode) -> OpenOptions& {
   mode_ = mode;
   return *this;
@@ -268,7 +262,6 @@ xyco::fs::uring::OpenOptions::OpenOptions()
       truncate_(false),
       create_(false),
       create_new_(false),
-      custom_flags_(0),
       mode_(default_mode_) {}
 
 auto xyco::fs::uring::OpenOptions::get_access_mode() const

--- a/src/fs/io_uring/file.h
+++ b/src/fs/io_uring/file.h
@@ -205,8 +205,6 @@ class OpenOptions {
 
   auto create_new(bool create_new) -> OpenOptions &;
 
-  auto custom_flags(int32_t flags) -> OpenOptions &;
-
   auto mode(uint32_t mode) -> OpenOptions &;
 
   OpenOptions();
@@ -226,7 +224,6 @@ class OpenOptions {
   bool create_;
   bool create_new_;
   // system-specific
-  int32_t custom_flags_;
   mode_t mode_;
 };
 }  // namespace xyco::fs::uring

--- a/src/io/epoll/registry.h
+++ b/src/io/epoll/registry.h
@@ -35,7 +35,7 @@ class IoRegistry : public runtime::Registry {
 
  private:
   constexpr static std::chrono::milliseconds MAX_TIMEOUT =
-      std::chrono::milliseconds(2);
+      std::chrono::milliseconds(1);
   constexpr static int MAX_EVENTS = 10000;
 
   int epfd_;

--- a/src/io/io_uring/registry.h
+++ b/src/io/io_uring/registry.h
@@ -11,7 +11,7 @@ namespace xyco::io::uring {
 class IoRegistry : public runtime::Registry {
  public:
   constexpr static std::chrono::milliseconds MAX_TIMEOUT =
-      std::chrono::milliseconds(2);
+      std::chrono::milliseconds(1);
   static const int MAX_EVENTS = 10000;
 
   [[nodiscard]] auto Register(std::shared_ptr<runtime::Event> event)

--- a/tests/runtime/future.cc
+++ b/tests/runtime/future.cc
@@ -106,11 +106,14 @@ TEST(RuntimeDeathTest, terminate) {
                       .max_blocking_threads(1)
                       .build()
                       .unwrap();
+        // Waits a few ms to complete runtime workers initialization.
+        std::this_thread::sleep_for(wait_interval);
+
         rt->spawn([]() -> xyco::runtime::Future<void> {
           throw std::runtime_error("");
           co_return;
         }());
-        std::this_thread::sleep_for(2 * wait_interval);
+        std::this_thread::sleep_for(wait_interval);
       },
       "");
 }
@@ -125,6 +128,8 @@ TEST(RuntimeDeathTest, coroutine_exception) {
                         .max_blocking_threads(1)
                         .build()
                         .unwrap();
+          std::this_thread::sleep_for(wait_interval);
+
           rt->spawn([]() -> xyco::runtime::Future<void> {
             throw std::runtime_error("");
             co_return;
@@ -189,6 +194,7 @@ TEST(RuntimeDeathTest, drop_parameter) {
                         .max_blocking_threads(1)
                         .build()
                         .unwrap();
+          std::this_thread::sleep_for(wait_interval);
 
           auto drop_asserter = DropAsserter(2);
           rt->spawn(


### PR DESCRIPTION
# Feature
- Deprecate `custom_flags` in fs module since it is only useful in win platform.
- Add more file unit tests to improve fs module coverage.
- Set io registry select timeout value to 1ms to shorten runtime worker iteration time.