### PR TITLE
[Test] Wait infinitely in the end of runtime death tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ FetchContent_Declare(GSL
 FetchContent_MakeAvailable(GSL)
 FetchContent_Declare(spdlog
                      GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
-                     GIT_TAG v1.x)
+                     GIT_TAG v1.10.0)
 FetchContent_MakeAvailable(spdlog)
 FetchContent_Declare(asio
                      GIT_REPOSITORY "https://github.com/chriskohlhoff/asio.git"


### PR DESCRIPTION
# Feature
- Fix error Github unit tests check failed frequently by waiting infinitely in the end of runtime death tests since these tests' time cost varies in an unpredictable range.
- Lock spdlog version to 1.10.0 to avoid clang tidy error of bundle fmt headers.