### PR TITLE
[Fix] Logging not works in dependencies in bazel build binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,3 +11,5 @@ build:opt --copt=-O3
 
 build:coverage --experimental_use_llvm_covmap
 build:coverage --experimental_generate_llvm_lcov
+
+build:enable_logging --define=enable_logging=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         run: |
           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang++-$llvm_version -S . -B ./build -G "Ninja"
           cmake --build ./build --config Release --target all
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang++-$llvm_version -DENABLE_LOGGING=ON -S . -B ./build -G "Ninja"
+          cmake --build ./build --config Release --target all
           bazel build --config=opt //benchmark:all //examples:all //src:all //tests:all
           bazel build --config=opt --config=enable_logging //benchmark:all //examples:all //src:all //tests:all
           rustup override set nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang++-$llvm_version -S . -B ./build -G "Ninja"
           cmake --build ./build --config Release --target all
           bazel build --config=opt //benchmark:all //examples:all //src:all //tests:all
+          bazel build --config=opt --config=enable_logging //benchmark:all //examples:all //src:all //tests:all
           rustup override set nightly
           cargo run --manifest-path tools/Cargo.toml -p git-hooks -- check clang-format --source src benchmark tests examples --tool-version $llvm_version
           cargo run --manifest-path tools/Cargo.toml -p git-hooks -- check clang-tidy --source src benchmark examples --build build --tool-version $llvm_version --extra-arg="-I/usr/lib/llvm-$llvm_version/include/c++/v1/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: test
         run: |
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
+          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
+          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
           mv $(bazel info bazel-testlogs)/tests/xyco_test_epoll/coverage.dat coverage_epoll.dat && mv $(bazel info bazel-testlogs)/tests/xyco_test_uring/coverage.dat coverage_uring.dat
       - name: upload epoll coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: test
         run: |
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
-          bazel coverage --config=opt --config=coverage --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
+          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
+          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
           mv $(bazel info bazel-testlogs)/tests/xyco_test_epoll/coverage.dat coverage_epoll.dat && mv $(bazel info bazel-testlogs)/tests/xyco_test_uring/coverage.dat coverage_uring.dat
       - name: upload epoll coverage report
         uses: codecov/codecov-action@v3

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -7,7 +7,6 @@ cc_binary(
         "//src/io:io_epoll",
         "//src/net:net_epoll",
         "//src/runtime",
-        "//src/utils:logging",
     ],
 )
 
@@ -18,6 +17,5 @@ cc_binary(
         "//src/io:io_uring",
         "//src/net:net_uring",
         "//src/runtime",
-        "//src/utils:logging",
     ],
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,6 @@ if(ENABLE_LOGGING)
     target_link_libraries(utils logging)
 endif(ENABLE_LOGGING)
 
-
 add_library(logging "utils/logger.cc")
 target_link_libraries(logging spdlog)
 target_compile_definitions(logging PUBLIC XYCO_ENABLE_LOG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(xyco_epoll_main main.cc)
-target_link_libraries(xyco_epoll_main io_epoll net_epoll runtime logging)
+target_link_libraries(xyco_epoll_main io_epoll net_epoll runtime)
 
 add_executable(xyco_uring_main main.cc)
-target_link_libraries(xyco_uring_main io_uring net_uring runtime logging)
+target_link_libraries(xyco_uring_main io_uring net_uring runtime)
 
 set(fs_epoll_src "fs/utils.cc" "fs/epoll/file.cc")
 set(fs_uring_src "fs/utils.cc" "fs/io_uring/file.cc")
@@ -55,8 +55,14 @@ target_link_libraries(runtime utils GSL)
 add_library(time ${time_src})
 target_link_libraries(time runtime spdlog)
 
+option(ENABLE_LOGGING "OFF")
+
 add_library(utils ${utils_src})
 target_link_libraries(utils spdlog ${Boost_STACKTRACE_ADDR2LINE_LIBRARY})
+if(ENABLE_LOGGING)
+    target_link_libraries(utils logging)
+endif(ENABLE_LOGGING)
+
 
 add_library(logging "utils/logger.cc")
 target_link_libraries(logging spdlog)

--- a/src/fs/epoll/file.cc
+++ b/src/fs/epoll/file.cc
@@ -311,3 +311,15 @@ auto xyco::fs::epoll::OpenOptions::get_creation_mode() const
   }
   return utils::Result<int>::ok(O_CREAT | O_EXCL);
 }
+
+template <typename FormatContext>
+auto fmt::formatter<xyco::fs::epoll::File>::format(
+    const xyco::fs::epoll::File& file, FormatContext& ctx) const
+    -> decltype(ctx.out()) {
+  return format_to(ctx.out(), "File{{fd_={}}}", file.fd_);
+}
+
+template auto fmt::formatter<xyco::fs::epoll::File>::format(
+    const xyco::fs::epoll::File& addr,
+    fmt::basic_format_context<fmt::appender, char>& ctx) const
+    -> decltype(ctx.out());

--- a/src/fs/epoll/file.cc
+++ b/src/fs/epoll/file.cc
@@ -316,7 +316,7 @@ template <typename FormatContext>
 auto fmt::formatter<xyco::fs::epoll::File>::format(
     const xyco::fs::epoll::File& file, FormatContext& ctx) const
     -> decltype(ctx.out()) {
-  return format_to(ctx.out(), "File{{fd_={}}}", file.fd_);
+  return format_to(ctx.out(), "File{{path_={}}}", file.path_.c_str());
 }
 
 template auto fmt::formatter<xyco::fs::epoll::File>::format(

--- a/src/fs/epoll/file.h
+++ b/src/fs/epoll/file.h
@@ -16,6 +16,7 @@
 namespace xyco::fs::epoll {
 class File {
   friend class OpenOptions;
+  friend struct fmt::formatter<File>;
 
  public:
   static auto create(std::filesystem::path &&path)
@@ -123,5 +124,12 @@ class OpenOptions {
   mode_t mode_;
 };
 }  // namespace xyco::fs::epoll
+
+template <>
+struct fmt::formatter<xyco::fs::epoll::File> : public fmt::formatter<bool> {
+  template <typename FormatContext>
+  auto format(const xyco::fs::epoll::File &file, FormatContext &ctx) const
+      -> decltype(ctx.out());
+};
 
 #endif  // XYCO_FS_EPOLL_FILE_H_

--- a/src/fs/io_uring/file.cc
+++ b/src/fs/io_uring/file.cc
@@ -316,7 +316,7 @@ template <typename FormatContext>
 auto fmt::formatter<xyco::fs::uring::File>::format(
     const xyco::fs::uring::File& file, FormatContext& ctx) const
     -> decltype(ctx.out()) {
-  return format_to(ctx.out(), "File{{fd_={}}}", file.fd_);
+  return format_to(ctx.out(), "File{{path_={}}}", file.path_.c_str());
 }
 
 template auto fmt::formatter<xyco::fs::uring::File>::format(

--- a/src/fs/io_uring/file.cc
+++ b/src/fs/io_uring/file.cc
@@ -311,3 +311,15 @@ auto xyco::fs::uring::OpenOptions::get_creation_mode() const
   }
   return utils::Result<int>::ok(O_CREAT | O_EXCL);
 }
+
+template <typename FormatContext>
+auto fmt::formatter<xyco::fs::uring::File>::format(
+    const xyco::fs::uring::File& file, FormatContext& ctx) const
+    -> decltype(ctx.out()) {
+  return format_to(ctx.out(), "File{{fd_={}}}", file.fd_);
+}
+
+template auto fmt::formatter<xyco::fs::uring::File>::format(
+    const xyco::fs::uring::File& addr,
+    fmt::basic_format_context<fmt::appender, char>& ctx) const
+    -> decltype(ctx.out());

--- a/src/fs/io_uring/file.h
+++ b/src/fs/io_uring/file.h
@@ -16,6 +16,7 @@
 namespace xyco::fs::uring {
 class File {
   friend class OpenOptions;
+  friend struct fmt::formatter<File>;
 
  public:
   static auto create(std::filesystem::path &&path)
@@ -227,5 +228,12 @@ class OpenOptions {
   mode_t mode_;
 };
 }  // namespace xyco::fs::uring
+
+template <>
+struct fmt::formatter<xyco::fs::uring::File> : public fmt::formatter<bool> {
+  template <typename FormatContext>
+  auto format(const xyco::fs::uring::File &file, FormatContext &ctx) const
+      -> decltype(ctx.out());
+};
 
 #endif  // XYCO_FS_IO_URING_FILE_H_

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -4,7 +4,8 @@ template <typename FormatContext>
 auto fmt::formatter<xyco::runtime::Event>::format(
     const xyco::runtime::Event &event, FormatContext &ctx) const
     -> decltype(ctx.out()) {
-  return format_to(ctx.out(), "Event{{extra_={}}}", event.extra_->print());
+  return format_to(ctx.out(), "Event{{extra_={}}}",
+                   event.extra_ ? event.extra_->print() : "nullptr");
 }
 
 template auto fmt::formatter<xyco::runtime::Event>::format(

--- a/src/utils/BUILD.bazel
+++ b/src/utils/BUILD.bazel
@@ -12,7 +12,10 @@ cc_library(
     deps = [
         "@spdlog",
         "@stacktrace",
-    ],
+    ] + select({
+        ":enable_logging": ["logging"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -24,4 +27,11 @@ cc_library(
     defines = ["XYCO_ENABLE_LOG"],
     visibility = ["//visibility:public"],
     deps = ["@spdlog"],
+)
+
+config_setting(
+    name = "enable_logging",
+    values = {
+        "define": "enable_logging=true",
+    },
 )

--- a/src/utils/logger.cc
+++ b/src/utils/logger.cc
@@ -11,7 +11,7 @@ auto LoggerCtx::get_logger() -> std::shared_ptr<spdlog::logger> {
     console_sink->set_level(spdlog::level::level_enum::debug);
     console_sink->set_pattern("[%C-%m-%d %T.%e] [%l] [%t] [%@] %v");
     auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(
-        "/var/log/xyco/runtime.txt", 0, 0, true);
+        "runtime.txt", 0, 0, true);
 
     auto logger = std::make_shared<spdlog::logger>(
         spdlog::logger("xyco", {console_sink, file_sink}));

--- a/tests/utils/fmt_test.cc
+++ b/tests/utils/fmt_test.cc
@@ -77,3 +77,15 @@ TEST(FmtTypeTest, Socket) {
 
   ASSERT_EQ(fmt_str, "Socket{fd_=-1}");
 }
+
+TEST(FmtTypeTest, File) {
+  TestRuntimeCtx::co_run([&]() -> xyco::runtime::Future<void> {
+    auto file = (co_await xyco::fs::File ::create("README.md")).unwrap();
+
+    auto fmt_str = fmt::format("{}", file);
+
+    CO_ASSERT_EQ(fmt_str, "File{path_=README.md}");
+
+    std::filesystem::remove("README.md");
+  });
+}


### PR DESCRIPTION
# Feature
- Fix error: Logging not works in dependencies in bazel build binaries.
- Add config to control whether enabling logging.
- Enable logging in unit test checks to better locate the critical path of failure.