### PR TITLE
[Fix] Reverts #41

### DIFF
--- a/src/runtime/future.cc
+++ b/src/runtime/future.cc
@@ -10,9 +10,7 @@ auto xyco::runtime::Future<void>::PromiseType::final_suspend() noexcept
   // 'future_ == nullptr' means:
   // future dropped but coroutine frame still exists(now only happen in
   // Runtime::spawn)
-  return {future_ != nullptr
-              ? (future_->has_suspend_ ? future_->waiting_ : nullptr)
-              : nullptr};
+  return {future_ != nullptr ? future_->waiting_ : nullptr};
 }
 
 auto xyco::runtime::Future<void>::PromiseType::unhandled_exception() -> void {
@@ -70,7 +68,6 @@ auto xyco::runtime::Future<void>::operator=(Future<void> &&future) noexcept
     -> Future<void> & {
   self_ = future.self_;
   future.self_ = nullptr;
-  has_suspend_ = future.has_suspend_;
   waiting_ = future.waiting_;
   future.waiting_ = nullptr;
   waited_ = future.waited_;
@@ -89,7 +86,7 @@ xyco::runtime::Future<void>::~Future() {
     if (!waiting_) {
       self_.promise().future_ = nullptr;
     }
-    if (waiting_ && has_suspend_) {
+    if (waiting_) {
       self_.destroy();
     }
   }

--- a/tests/runtime/future.cc
+++ b/tests/runtime/future.cc
@@ -72,7 +72,9 @@ TEST_F(InRuntimeTest, NoSuspend_loop) {
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto co_innner = []() -> xyco::runtime::Future<int> { co_return 1; };
 
-    for (int i = 0; i < ITERATION_TIMES; i++) {
+    // NOTE: Iteration times should be restricted carefully in this no suspend
+    // loop case to avoid stack overflow.
+    for (int i = 0; i < ITERATION_TIMES / 8; i++) {
       int co_result = -1;
       co_result = co_await co_innner();
 


### PR DESCRIPTION
# Fix
## Revert #41 due to the corner case in multi-thread runtime:
1. A chained coroutine reaches the suspend point. It registers a event to the driver and then the underlying thread was suspended by the os.
2. The event in the driver is ready and another thread resumes the coroutine. It runs till the end and the underlying objects are destructed.
3. First thread resumes, so it continues at the first line after the `resume()` in `await_suspend`. But the next blocks contains references to the destructed `Future` which leads to weird behavior.
## Cons
In a nested no suspend coroutines(like coroutine recursion or coroutine in a loop), the stack depth grows twice as the speed of the usual recursion.