### PR TITLE
[Fix] Prints critical ut log in ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,5 +16,6 @@ build:coverage --experimental_use_llvm_covmap
 build:coverage --experimental_generate_llvm_lcov
 build:coverage --instrument_test_targets
 build:coverage --instrumentation_filter="//src[/:],//tests[/:]"
+build:coverage --experimental_ui_max_stdouterr_bytes=-1
 
 build:enable_logging --define=enable_logging=true

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -13,11 +13,11 @@ jobs:
   test-codecov:
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v3
       - name: install essential packages
         run: |
           sudo apt-get install -y lcov liburing-dev libboost-all-dev
           sudo bash scripts/install_llvm.sh $llvm_version
-      - uses: actions/checkout@v3
       - name: test
         run: |
           bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe

--- a/src/utils/panic.cc
+++ b/src/utils/panic.cc
@@ -4,13 +4,11 @@
 #include <iostream>
 
 #include "boost/stacktrace.hpp"
-#include "logger.h"
 
 auto xyco::utils::panic(const std::string &info) -> void {
   auto unwind_info = std::format("Panic:{}\n{}", info,
                                  to_string(boost::stacktrace::stacktrace()));
 
   std::cerr << unwind_info;
-  ERROR("{}", unwind_info);
   throw std::runtime_error(unwind_info);
 }

--- a/tests/net/tcp.cc
+++ b/tests/net/tcp.cc
@@ -201,8 +201,10 @@ TEST_F(WithServerTest, TcpListener_accept) {
 TEST_F(WithServerTest, TcpStream_rw_loop) {
   constexpr int ITERATION_TIMES = 100000;
 
+#ifdef XYCO_ENABLE_LOG
   auto original_level = LoggerCtx::get_logger()->level();
   LoggerCtx::get_logger()->set_level(spdlog::level::off);
+#endif
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto client = (co_await xyco::net::TcpStream::connect(
                        xyco::net::SocketAddr::new_v4(ip_, port_)))
@@ -221,7 +223,9 @@ TEST_F(WithServerTest, TcpStream_rw_loop) {
       CO_ASSERT_EQ(r_nbytes, r_buf.size());
     }
   });
+#ifdef XYCO_ENABLE_LOG
   LoggerCtx::get_logger()->set_level(original_level);
+#endif
 }
 
 TEST_F(WithServerTest, TcpStream_rw_twice) {

--- a/tests/net/tcp.cc
+++ b/tests/net/tcp.cc
@@ -201,6 +201,8 @@ TEST_F(WithServerTest, TcpListener_accept) {
 TEST_F(WithServerTest, TcpStream_rw_loop) {
   constexpr int ITERATION_TIMES = 100000;
 
+  auto original_level = LoggerCtx::get_logger()->level();
+  LoggerCtx::get_logger()->set_level(spdlog::level::off);
   TestRuntimeCtx::co_run([]() -> xyco::runtime::Future<void> {
     auto client = (co_await xyco::net::TcpStream::connect(
                        xyco::net::SocketAddr::new_v4(ip_, port_)))
@@ -219,6 +221,7 @@ TEST_F(WithServerTest, TcpStream_rw_loop) {
       CO_ASSERT_EQ(r_nbytes, r_buf.size());
     }
   });
+  LoggerCtx::get_logger()->set_level(original_level);
 }
 
 TEST_F(WithServerTest, TcpStream_rw_twice) {

--- a/tests/utils/result_test.cc
+++ b/tests/utils/result_test.cc
@@ -25,16 +25,22 @@ class ResultTest : public ::testing::Test {
     void_t_void_e_ok_ = Result<void, void>::ok();
     void_t_void_e_err_ = Result<void, void>::err();
 
+#ifdef XYCO_ENABLE_LOG
     original_level_ = LoggerCtx::get_logger()->level();
     LoggerCtx::get_logger()->set_level(spdlog::level::off);
+#endif
   }
 
   void TearDown() override {
+#ifdef XYCO_ENABLE_LOG
     LoggerCtx::get_logger()->set_level(original_level_);
+#endif
   }
 
  private:
+#ifdef XYCO_ENABLE_LOG
   spdlog::level::level_enum original_level_{};
+#endif
 
  public:
   Result<int, int> no_void_ok_;

--- a/tests/utils/result_test.cc
+++ b/tests/utils/result_test.cc
@@ -24,7 +24,17 @@ class ResultTest : public ::testing::Test {
     void_e_err_ = Result<int, void>::err();
     void_t_void_e_ok_ = Result<void, void>::ok();
     void_t_void_e_err_ = Result<void, void>::err();
+
+    original_level_ = LoggerCtx::get_logger()->level();
+    LoggerCtx::get_logger()->set_level(spdlog::level::off);
   }
+
+  void TearDown() override {
+    LoggerCtx::get_logger()->set_level(original_level_);
+  }
+
+ private:
+  spdlog::level::level_enum original_level_{};
 
  public:
   Result<int, int> no_void_ok_;


### PR DESCRIPTION
# Overview
- Removes the max output bytes restriction of bazel to print detailed log in ut.
- Discards some repeated log in ut to avoid submerging the critical info.
- Fixes the bug that post merge ci fails to install llvm toolchain.