### PR TITLE
[Fix] Applies synchronous register to avoid lock starvation

### DIFF
--- a/src/io/epoll/registry.h
+++ b/src/io/epoll/registry.h
@@ -1,6 +1,7 @@
 #ifndef XYCO_NET_EPOLL_REGISTRY_H_
 #define XYCO_NET_EPOLL_REGISTRY_H_
 
+#include <mutex>
 #include <vector>
 
 #include "runtime/registry.h"
@@ -39,6 +40,7 @@ class IoRegistry : public runtime::Registry {
   constexpr static int MAX_EVENTS = 10000;
 
   int epfd_;
+  std::mutex events_mutex_;
   std::vector<std::shared_ptr<runtime::Event>> registered_events_;
 };
 }  // namespace xyco::io::epoll

--- a/src/io/io_uring/registry.h
+++ b/src/io/io_uring/registry.h
@@ -8,7 +8,7 @@
 #include "runtime/registry.h"
 
 namespace xyco::io::uring {
-class IoRegistry : public runtime::Registry {
+class IoRegistry : public runtime::GlobalRegistry {
  public:
   constexpr static std::chrono::milliseconds MAX_TIMEOUT =
       std::chrono::milliseconds(1);
@@ -27,6 +27,17 @@ class IoRegistry : public runtime::Registry {
                             std::chrono::milliseconds timeout)
       -> utils::Result<void> override;
 
+  auto register_local(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override;
+
+  auto reregister_local(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override;
+
+  auto deregister_local(std::shared_ptr<xyco::runtime::Event> event)
+      -> xyco::utils::Result<void> override;
+
+  auto local_registry_init() -> void override;
+
   IoRegistry(uint32_t entries);
 
   IoRegistry(const IoRegistry& registry) = delete;
@@ -37,11 +48,10 @@ class IoRegistry : public runtime::Registry {
 
   auto operator=(IoRegistry&& registry) -> IoRegistry& = delete;
 
-  ~IoRegistry() override;
+  ~IoRegistry() override = default;
 
  private:
-  struct io_uring io_uring_;
-  std::vector<std::shared_ptr<runtime::Event>> registered_events_;
+  uint32_t uring_capacity_;
 };
 }  // namespace xyco::io::uring
 

--- a/src/runtime/driver.cc
+++ b/src/runtime/driver.cc
@@ -2,14 +2,6 @@
 
 #include "runtime.h"
 
-thread_local std::unordered_map<decltype(typeid(int).hash_code()),
-                                std::shared_ptr<xyco::runtime::Event>>
-    xyco::runtime::Driver::register_events_;
-
-thread_local std::unordered_map<decltype(typeid(int).hash_code()),
-                                std::shared_ptr<xyco::runtime::Event>>
-    xyco::runtime::Driver::reregister_events_;
-
 auto xyco::runtime::Driver::poll() -> void {
   runtime::Events events;
 
@@ -24,25 +16,6 @@ auto xyco::runtime::Driver::poll() -> void {
     std::scoped_lock<std::mutex> lock_guard(mutexes_[key]);
     registry->select(events, MAX_TIMEOUT).unwrap();
     RuntimeCtx::get_ctx()->wake(events);
-  }
-}
-
-auto xyco::runtime::Driver::dispatch() -> void {
-  {
-    std::scoped_lock<std::mutex> lock_guard(register_mutex_);
-    for (auto&& pair : register_events_) {
-      std::scoped_lock<std::mutex> lock_guard(mutexes_[pair.first]);
-      registries_.find(pair.first)->second->Register(pair.second).unwrap();
-    }
-    register_events_.clear();
-  }
-  {
-    std::scoped_lock<std::mutex> lock_guard(reregister_mutex_);
-    for (auto&& pair : reregister_events_) {
-      std::scoped_lock<std::mutex> lock_guard(mutexes_[pair.first]);
-      registries_.find(pair.first)->second->reregister(pair.second).unwrap();
-    }
-    reregister_events_.clear();
   }
 }
 

--- a/src/runtime/registry.h
+++ b/src/runtime/registry.h
@@ -7,7 +7,7 @@ namespace xyco::runtime {
 class FutureBase;
 class Registry;
 class Event;
-using Events = std::vector<std::weak_ptr<Event>>;
+using Events = std::vector<std::shared_ptr<Event>>;
 
 class Extra {
  public:

--- a/src/time/wheel.cc
+++ b/src/time/wheel.cc
@@ -5,12 +5,11 @@
 
 xyco::time::Level::Level() : current_it_(events_.begin()) {}
 
-auto xyco::time::Wheel::insert_event(std::weak_ptr<runtime::Event> event)
+auto xyco::time::Wheel::insert_event(std::shared_ptr<runtime::Event> event)
     -> void {
   auto total_steps =
       std::chrono::duration_cast<std::chrono::milliseconds>(
-          dynamic_cast<TimeExtra *>(event.lock()->extra_.get())->expire_time_ -
-          now_)
+          dynamic_cast<TimeExtra *>(event->extra_.get())->expire_time_ - now_)
           .count();
 
   auto level = 0;

--- a/src/time/wheel.h
+++ b/src/time/wheel.h
@@ -24,7 +24,7 @@ class Level {
 
 class Wheel {
  public:
-  auto insert_event(std::weak_ptr<runtime::Event> event) -> void;
+  auto insert_event(std::shared_ptr<runtime::Event> event) -> void;
 
   auto expire(runtime::Events &events) -> void;
 


### PR DESCRIPTION
# Overview
- Allows concurrent calling `Register` & `reregister` without locking first.

Mainly to avoid the situation: Some threads are blocked for a long time(can reach to more than 10s) by acquiring lock when registering an event.
- Applies one-ring-per-worker policy for io uring registry to bypass the multithread submitting problem of liburing.

Drawbacks: Current implementation forfeits the multithreading performance advantage due to thread bound `Event`.