### PR TITLE
[Refactor] Async future return type deduction

### DIFF
--- a/benchmark/echo_server.cc
+++ b/benchmark/echo_server.cc
@@ -49,8 +49,8 @@ auto main() -> int {
   constexpr uint16_t port = 8080;
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto server = Server(xyco::runtime::Builder::new_multi_thread()
-                           .worker_threads(1)
-                           .max_blocking_threads(1)
+                           .worker_threads(2)
+                           .max_blocking_threads(2)
                            .registry<xyco::io::IoRegistry>(4)
                            .build()
                            .unwrap(),

--- a/src/fs/epoll/file.cc
+++ b/src/fs/epoll/file.cc
@@ -23,8 +23,7 @@ auto epoll_file_attr(int file_descriptor) -> xyco::runtime::Future<
   struct statx stx {};
   struct stat64 stat {};
 
-  ASYNC_TRY((co_await xyco::runtime::AsyncFuture<
-                 xyco::utils::Result<int>>([&]() {
+  ASYNC_TRY((co_await xyco::runtime::AsyncFuture([&]() {
               return xyco::utils::into_sys_result(statx(
                   file_descriptor, "\0", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
                   STATX_ALL, &stx));
@@ -105,7 +104,7 @@ auto xyco::fs::epoll::File::open(std::filesystem::path path)
 
 auto xyco::fs::epoll::File::resize(uintmax_t size)
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::resize_file(path_, size, error_code);
     return !error_code ? utils::Result<void>::ok()
@@ -117,7 +116,7 @@ auto xyco::fs::epoll::File::resize(uintmax_t size)
 
 auto xyco::fs::epoll::File::size() const
     -> runtime::Future<utils::Result<uintmax_t>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<uintmax_t>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     auto len = std::filesystem::file_size(path_, error_code);
     return !error_code ? utils::Result<uintmax_t>::ok(len)
@@ -129,8 +128,7 @@ auto xyco::fs::epoll::File::size() const
 
 auto xyco::fs::epoll::File::status()
     -> runtime::Future<utils::Result<std::filesystem::file_status>> {
-  co_return co_await runtime::AsyncFuture<
-      utils::Result<std::filesystem::file_status>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::file_status status;
     if (std::filesystem::is_symlink(path_)) {
@@ -148,7 +146,7 @@ auto xyco::fs::epoll::File::status()
 auto xyco::fs::epoll::File::set_permissions(
     std::filesystem::perms prms, std::filesystem::perm_options opts) const
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::permissions(path_, prms, opts, error_code);
     return !error_code ? utils::Result<void>::ok()
@@ -160,13 +158,13 @@ auto xyco::fs::epoll::File::set_permissions(
 
 auto xyco::fs::epoll::File::flush() const
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>(
+  co_return co_await runtime::AsyncFuture(
       [=]() { return utils::into_sys_result(::fsync(fd_)); });
 }
 
 auto xyco::fs::epoll::File::seek(off64_t offset, int whence) const
     -> runtime::Future<utils::Result<off64_t>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<off64_t>>([=]() {
+  co_return co_await runtime::AsyncFuture([=]() {
     auto return_offset = ::lseek64(fd_, offset, whence);
     if (return_offset == -1) {
       return utils::into_sys_result(-1).map(
@@ -201,7 +199,7 @@ xyco::fs::epoll::File::File(int file_descriptor, std::filesystem::path&& path)
 
 auto xyco::fs::epoll::OpenOptions::open(std::filesystem::path path)
     -> runtime::Future<utils::Result<File>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<File>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     auto access_mode = get_access_mode();
     if (access_mode.is_err()) {
       return access_mode.map(

--- a/src/fs/epoll/file.h
+++ b/src/fs/epoll/file.h
@@ -48,7 +48,7 @@ class File {
   template <typename Iterator>
   auto read(Iterator begin, Iterator end)
       -> runtime::Future<utils::Result<uintptr_t>> {
-    co_return co_await runtime::AsyncFuture<utils::Result<uintptr_t>>([&]() {
+    co_return co_await runtime::AsyncFuture([&]() {
       return utils::into_sys_result(
           ::read(fd_, &*begin, std::distance(begin, end)));
     });
@@ -57,7 +57,7 @@ class File {
   template <typename Iterator>
   auto write(Iterator begin, Iterator end)
       -> runtime::Future<utils::Result<uintptr_t>> {
-    co_return co_await runtime::AsyncFuture<utils::Result<uintptr_t>>([&]() {
+    co_return co_await runtime::AsyncFuture([&]() {
       return utils::into_sys_result(
           ::write(fd_, &*begin, std::distance(begin, end)));
     });

--- a/src/fs/io_uring/file.cc
+++ b/src/fs/io_uring/file.cc
@@ -1,4 +1,3 @@
-
 #include "file.h"
 
 #include <__utility/to_underlying.h>
@@ -23,8 +22,7 @@ auto uring_file_attr(int file_descriptor) -> xyco::runtime::Future<
   struct statx stx {};
   struct stat64 stat {};
 
-  ASYNC_TRY((co_await xyco::runtime::AsyncFuture<
-                 xyco::utils::Result<int>>([&]() {
+  ASYNC_TRY((co_await xyco::runtime::AsyncFuture([&]() {
               return xyco::utils::into_sys_result(statx(
                   file_descriptor, "\0", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
                   STATX_ALL, &stx));
@@ -105,7 +103,7 @@ auto xyco::fs::uring::File::open(std::filesystem::path path)
 
 auto xyco::fs::uring::File::resize(uintmax_t size)
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::resize_file(path_, size, error_code);
     return !error_code ? utils::Result<void>::ok()
@@ -117,7 +115,7 @@ auto xyco::fs::uring::File::resize(uintmax_t size)
 
 auto xyco::fs::uring::File::size() const
     -> runtime::Future<utils::Result<uintmax_t>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<uintmax_t>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     auto len = std::filesystem::file_size(path_, error_code);
     return !error_code ? utils::Result<uintmax_t>::ok(len)
@@ -129,8 +127,7 @@ auto xyco::fs::uring::File::size() const
 
 auto xyco::fs::uring::File::status()
     -> runtime::Future<utils::Result<std::filesystem::file_status>> {
-  co_return co_await runtime::AsyncFuture<
-      utils::Result<std::filesystem::file_status>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::file_status status;
     if (std::filesystem::is_symlink(path_)) {
@@ -148,7 +145,7 @@ auto xyco::fs::uring::File::status()
 auto xyco::fs::uring::File::set_permissions(
     std::filesystem::perms prms, std::filesystem::perm_options opts) const
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::permissions(path_, prms, opts, error_code);
     return !error_code ? utils::Result<void>::ok()
@@ -160,13 +157,13 @@ auto xyco::fs::uring::File::set_permissions(
 
 auto xyco::fs::uring::File::flush() const
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>(
+  co_return co_await runtime::AsyncFuture(
       [=]() { return utils::into_sys_result(::fsync(fd_)); });
 }
 
 auto xyco::fs::uring::File::seek(off64_t offset, int whence) const
     -> runtime::Future<utils::Result<off64_t>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<off64_t>>([=]() {
+  co_return co_await runtime::AsyncFuture([=]() {
     auto return_offset = ::lseek64(fd_, offset, whence);
     if (return_offset == -1) {
       return utils::into_sys_result(-1).map(
@@ -201,7 +198,7 @@ xyco::fs::uring::File::File(int file_descriptor, std::filesystem::path&& path)
 
 auto xyco::fs::uring::OpenOptions::open(std::filesystem::path path)
     -> runtime::Future<utils::Result<File>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<File>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     auto access_mode = get_access_mode();
     if (access_mode.is_err()) {
       return access_mode.map(

--- a/src/fs/utils.cc
+++ b/src/fs/utils.cc
@@ -5,7 +5,7 @@
 auto xyco::fs::rename(std::filesystem::path old_path,
                       std::filesystem::path new_path)
     -> runtime::Future<utils::Result<void>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<void>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     std::filesystem::rename(old_path, new_path, error_code);
 
@@ -18,7 +18,7 @@ auto xyco::fs::rename(std::filesystem::path old_path,
 
 auto xyco::fs::remove(std::filesystem::path path)
     -> runtime::Future<utils::Result<bool>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<bool>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     auto exist = std::filesystem::remove(path, error_code);
 
@@ -33,7 +33,7 @@ auto xyco::fs::copy_file(std::filesystem::path from_path,
                          std::filesystem::path to_path,
                          std::filesystem::copy_options options)
     -> runtime::Future<utils::Result<bool>> {
-  co_return co_await runtime::AsyncFuture<utils::Result<bool>>([&]() {
+  co_return co_await runtime::AsyncFuture([&]() {
     std::error_code error_code;
     auto ret =
         std::filesystem::copy_file(from_path, to_path, options, error_code);

--- a/src/net/epoll/listener.cc
+++ b/src/net/epoll/listener.cc
@@ -16,7 +16,7 @@ using Future = xyco::runtime::Future<T>;
 
 auto xyco::net::epoll::TcpSocket::bind(SocketAddr addr)
     -> Future<utils::Result<void>> {
-  auto bind_result = co_await runtime::AsyncFuture<utils::Result<int>>([&]() {
+  auto bind_result = co_await runtime::AsyncFuture([&]() {
     return utils::into_sys_result(
         ::bind(socket_.into_c_fd(), addr.into_c_addr(), sizeof(sockaddr)));
   });
@@ -83,11 +83,10 @@ auto xyco::net::epoll::TcpSocket::connect(SocketAddr addr)
     std::shared_ptr<runtime::Event> event_;
   };
 
-  auto connect_result =
-      co_await runtime::AsyncFuture<utils::Result<int>>([&]() {
-        return utils::into_sys_result(::connect(
-            socket_.into_c_fd(), addr.into_c_addr(), sizeof(sockaddr)));
-      });
+  auto connect_result = co_await runtime::AsyncFuture([&]() {
+    return utils::into_sys_result(
+        ::connect(socket_.into_c_fd(), addr.into_c_addr(), sizeof(sockaddr)));
+  });
   if (connect_result.is_ok()) {
     co_return CoOutput::ok(TcpStream(std::move(socket_), true));
   }
@@ -101,7 +100,7 @@ auto xyco::net::epoll::TcpSocket::connect(SocketAddr addr)
 
 auto xyco::net::epoll::TcpSocket::listen(int backlog)
     -> Future<utils::Result<TcpListener>> {
-  auto listen_result = co_await runtime::AsyncFuture<utils::Result<int>>([&]() {
+  auto listen_result = co_await runtime::AsyncFuture([&]() {
     return utils::into_sys_result(::listen(socket_.into_c_fd(), backlog));
   });
   ASYNC_TRY(listen_result.map([&](auto n) { return TcpListener(Socket(-1)); }));
@@ -155,7 +154,7 @@ auto xyco::net::epoll::TcpStream::flush() -> Future<utils::Result<void>> {
 
 auto xyco::net::epoll::TcpStream::shutdown(io::Shutdown shutdown) const
     -> Future<utils::Result<void>> {
-  ASYNC_TRY(co_await runtime::AsyncFuture<utils::Result<int>>([&]() {
+  ASYNC_TRY(co_await runtime::AsyncFuture([&]() {
     return utils::into_sys_result(::shutdown(
         socket_.into_c_fd(),
         static_cast<std::underlying_type_t<io::Shutdown>>(shutdown)));

--- a/src/net/io_uring/listener.cc
+++ b/src/net/io_uring/listener.cc
@@ -14,7 +14,7 @@ using Future = xyco::runtime::Future<T>;
 
 auto xyco::net::uring::TcpSocket::bind(SocketAddr addr)
     -> Future<utils::Result<void>> {
-  auto bind_result = co_await runtime::AsyncFuture<utils::Result<int>>([&]() {
+  auto bind_result = co_await runtime::AsyncFuture([&]() {
     return utils::into_sys_result(
         ::bind(socket_.into_c_fd(), addr.into_c_addr(), sizeof(sockaddr)));
   });
@@ -74,7 +74,7 @@ auto xyco::net::uring::TcpSocket::connect(SocketAddr addr)
 
 auto xyco::net::uring::TcpSocket::listen(int backlog)
     -> Future<utils::Result<TcpListener>> {
-  auto listen_result = co_await runtime::AsyncFuture<utils::Result<int>>([&]() {
+  auto listen_result = co_await runtime::AsyncFuture([&]() {
     return utils::into_sys_result(::listen(socket_.into_c_fd(), backlog));
   });
   ASYNC_TRY(listen_result.map([&](auto n) { return TcpListener(Socket(-1)); }));


### PR DESCRIPTION
# Overview
- Let compiler deduct `AsyncFuture` return type to discard redundant template type specification.