### PR TITLE
[Build] Upgrades to llvm 17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 build --crosstool_top=//toolchain:clang_suite
-build --linkopt=-fuse-ld=lld-16
+build --linkopt=-fuse-ld=lld-17
 build --linkopt=-lc++
 build --linkopt=-lm
 build --linkopt=-rdynamic

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -150,6 +150,8 @@ CheckOptions:
     value:           'false'
   - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
     value:           'false'
+  - key:             cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreNonDeducedTemplateTypes
+    value:           'true'
   - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
     value:           'false'
   - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - "build/*"
 
 env:
-  llvm_version: 16
+  llvm_version: 17
 
 jobs:
   rust-tool:

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -7,7 +7,7 @@ on:
       - "build/*"
 
 env:
-  llvm_version: 16
+  llvm_version: 17
 
 jobs:
   test-codecov:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(
 set(CMAKE_CXX_STANDARD 20)
 
 add_compile_options(-std=c++20 -stdlib=libc++ -fexperimental-library)
-add_link_options(-fuse-ld=lld-16 -lc++ -lm -rdynamic)
+add_link_options(-fuse-ld=lld-17 -lc++ -lm -rdynamic)
 
 include(FetchContent)
 FetchContent_Declare(googletest
@@ -25,8 +25,8 @@ FetchContent_Declare(spdlog
                      URL_HASH SHA256=697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224)
 FetchContent_MakeAvailable(spdlog)
 FetchContent_Declare(asio
-                     URL "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-24-0.tar.gz"
-                     URL_HASH SHA256=cbcaaba0f66722787b1a7c33afe1befb3a012b5af3ad7da7ff0f6b8c9b7a8a5b)
+                     URL "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-0.tar.gz"
+                     URL_HASH SHA256=226438b0798099ad2a202563a83571ce06dd13b570d8fded4840dbc1f97fa328)
 FetchContent_MakeAvailable(asio)
 
 include_directories(src)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -19,9 +19,9 @@ http_archive(
 http_archive(
     name = "asio",
     build_file = "//third_party/boost:asio.bazel",
-    sha256 = "cbcaaba0f66722787b1a7c33afe1befb3a012b5af3ad7da7ff0f6b8c9b7a8a5b",
-    strip_prefix = "asio-asio-1-24-0/asio",
-    url = "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-24-0.tar.gz",
+    sha256 = "226438b0798099ad2a202563a83571ce06dd13b570d8fded4840dbc1f97fa328",
+    strip_prefix = "asio-asio-1-28-0/asio",
+    url = "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-0.tar.gz",
 )
 
 http_archive(

--- a/examples/http_server.cc
+++ b/examples/http_server.cc
@@ -94,22 +94,23 @@ class Server {
  public:
   Server(std::unique_ptr<xyco::runtime::Runtime> runtime, uint16_t port)
       : runtime_(std::move(runtime)) {
-    auto init_server = [=](uint16_t port) -> xyco::runtime::Future<void> {
-      auto tcp_socket = xyco::net::TcpSocket::new_v4().unwrap();
-      tcp_socket.set_reuseaddr(true).unwrap();
-      (co_await tcp_socket.bind(xyco::net::SocketAddr::new_v4({}, port)))
-          .unwrap();
-      auto listener = (co_await tcp_socket.listen(LISTEN_BACKLOG)).unwrap();
-
-      while (true) {
-        auto server_stream = (co_await listener.accept()).unwrap().first;
-        runtime_->spawn(receive_request(std::move(server_stream)));
-      }
-    };
     runtime_->spawn(init_server(port));
   }
 
  private:
+  auto init_server(uint16_t port) -> xyco::runtime::Future<void> {
+    auto tcp_socket = xyco::net::TcpSocket::new_v4().unwrap();
+    tcp_socket.set_reuseaddr(true).unwrap();
+    (co_await tcp_socket.bind(xyco::net::SocketAddr::new_v4({}, port)))
+        .unwrap();
+    auto listener = (co_await tcp_socket.listen(LISTEN_BACKLOG)).unwrap();
+
+    while (true) {
+      auto server_stream = (co_await listener.accept()).unwrap().first;
+      runtime_->spawn(receive_request(std::move(server_stream)));
+    }
+  }
+
   auto receive_request(xyco::net::TcpStream server_stream)
       -> xyco::runtime::Future<void> {
     auto reader = xyco::io::BufferReader<xyco::net::TcpStream, std::string>(

--- a/scripts/install_llvm.sh
+++ b/scripts/install_llvm.sh
@@ -7,6 +7,6 @@ if [[ ! -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc ]]; then
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 fi
 
-add-apt-repository "deb http://apt.llvm.org/jammy/  llvm-toolchain-jammy-$LLVM_VERSION main"
+add-apt-repository "deb http://apt.llvm.org/jammy/  llvm-toolchain-jammy main"
 apt-get update
 apt-get install -y clang-$LLVM_VERSION lld-$LLVM_VERSION clang-tidy-$LLVM_VERSION clang-format-$LLVM_VERSION llvm-$LLVM_VERSION-dev lld-$LLVM_VERSION libc++-$LLVM_VERSION-dev libc++abi-$LLVM_VERSION-dev libunwind-$LLVM_VERSION-dev

--- a/src/fs/epoll/file.cc
+++ b/src/fs/epoll/file.cc
@@ -159,12 +159,12 @@ auto xyco::fs::epoll::File::set_permissions(
 auto xyco::fs::epoll::File::flush() const
     -> runtime::Future<utils::Result<void>> {
   co_return co_await runtime::AsyncFuture(
-      [=]() { return utils::into_sys_result(::fsync(fd_)); });
+      [this]() { return utils::into_sys_result(::fsync(fd_)); });
 }
 
 auto xyco::fs::epoll::File::seek(off64_t offset, int whence) const
     -> runtime::Future<utils::Result<off64_t>> {
-  co_return co_await runtime::AsyncFuture([=]() {
+  co_return co_await runtime::AsyncFuture([this, offset, whence]() {
     auto return_offset = ::lseek64(fd_, offset, whence);
     if (return_offset == -1) {
       return utils::into_sys_result(-1).map(

--- a/src/fs/io_uring/file.cc
+++ b/src/fs/io_uring/file.cc
@@ -158,12 +158,12 @@ auto xyco::fs::uring::File::set_permissions(
 auto xyco::fs::uring::File::flush() const
     -> runtime::Future<utils::Result<void>> {
   co_return co_await runtime::AsyncFuture(
-      [=]() { return utils::into_sys_result(::fsync(fd_)); });
+      [this]() { return utils::into_sys_result(::fsync(fd_)); });
 }
 
 auto xyco::fs::uring::File::seek(off64_t offset, int whence) const
     -> runtime::Future<utils::Result<off64_t>> {
-  co_return co_await runtime::AsyncFuture([=]() {
+  co_return co_await runtime::AsyncFuture([this, offset, whence]() {
     auto return_offset = ::lseek64(fd_, offset, whence);
     if (return_offset == -1) {
       return utils::into_sys_result(-1).map(

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -8,7 +8,7 @@ thread_local xyco::runtime::Runtime *xyco::runtime::RuntimeCtx::runtime_ =
     nullptr;
 
 auto xyco::runtime::Worker::lanuch(Runtime *runtime) -> void {
-  ctx_ = std::thread([=]() {
+  ctx_ = std::thread([this, runtime]() {
     runtime->on_start_f_();
     RuntimeCtx::set_ctx(runtime);
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -13,7 +13,7 @@ all_link_actions = [
     ACTION_NAMES.cpp_link_nodeps_dynamic_library,
 ]
 
-LLVM_VERSION = 16
+LLVM_VERSION = 17
 
 def _impl(ctx):
     tool_paths = [


### PR DESCRIPTION
# Overview
- Upgrades llvm toolchain version to 17.
- Upgrades to asio 1.28 due to compilation error of llvm 17 and asio 1.24 combination.
- Enables clang tidy `cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreNonDeducedTemplateTypes` to pass perfect forwarding.