### PR TITLE
[Fix] Fixes multithread waking error

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ build --linkopt=-lc++
 build --linkopt=-lm
 build --linkopt=-rdynamic
 build --linkopt=-lc++experimental
+build --linkopt=-L/usr/lib/llvm-17/lib
 build --cxxopt=-std=c++20
 build --cxxopt=-stdlib=libc++
 build --cxxopt=-fexperimental-library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@ project(
 set(CMAKE_CXX_STANDARD 20)
 
 add_compile_options(-std=c++20 -stdlib=libc++ -fexperimental-library)
-add_link_options(-fuse-ld=lld-17 -lc++ -lm -rdynamic)
+# FIXME(xiaoyu): llvm path added cuz latest toolchain fails to find 
+# c++experimental lib, removes it after toolchain fixed
+add_link_options(-fuse-ld=lld-17 -lc++ -lm -rdynamic -L/usr/lib/llvm-17/lib)
 
 include(FetchContent)
 FetchContent_Declare(googletest

--- a/src/runtime/driver.cc
+++ b/src/runtime/driver.cc
@@ -13,7 +13,11 @@ auto xyco::runtime::Driver::poll() -> void {
   }
 
   for (auto& [key, registry] : registries_) {
-    std::scoped_lock<std::mutex> lock_guard(mutexes_[key]);
+    std::unique_lock<std::mutex> lock_guard(mutexes_[key], std::try_to_lock);
+    if (!lock_guard) {
+      continue;
+    }
+
     registry->select(events, MAX_TIMEOUT).unwrap();
     RuntimeCtx::get_ctx()->wake(events);
   }


### PR DESCRIPTION
# Overview
- Restores the context first before giving back io events from io registry to avoid contaminating the next coroutine on the same event.
- Partially replaces some lock with try lock to avoid blocking worker main loop.
- Temp patch for `unable to find library -lc++experimental`.