### PR TITLE
[Chore] Reverts to CMake tool in Github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           cmake --build build --config Release --target xyco_test_epoll xyco_test_uring
           LLVM_PROFILE_FILE="build/tests/xyco_test_epoll.profraw" build/tests/xyco_test_epoll --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_epoll.profraw -o build/tests/xyco_test_epoll.profdata
-          llvm-cov-$llvm_version show build/tests/xyco_test_epoll -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_epoll.profdata > coverage_eopll.txt
+          llvm-cov-$llvm_version show build/tests/xyco_test_epoll -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_epoll.profdata > coverage_epoll.txt
           LLVM_PROFILE_FILE="build/tests/xyco_test_uring.profraw" build/tests/xyco_test_uring --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_uring.profraw -o build/tests/xyco_test_uring.profdata
           llvm-cov-$llvm_version show build/tests/xyco_test_uring -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_uring.profdata > coverage_uring.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install essential packages
         run: |
-          sudo apt-get install -y lcov liburing-dev libboost-all-dev
+          sudo apt-get install -y ninja-build lcov liburing-dev libboost-all-dev
           sudo bash scripts/install_llvm.sh $llvm_version
       - name: test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,10 @@ jobs:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
       - name: build
         run: |
-          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang-$llvm_version -S . -B ./build -G "Ninja"
-          cmake --build ./build --config Release --target all
-          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang-$llvm_version -DENABLE_LOGGING=ON -S . -B ./build -G "Ninja"
-          cmake --build ./build --config Release --target all
-          bazel build --config=opt //benchmark:all //examples:all //src:all //tests:all
-          bazel build --config=opt --config=enable_logging //benchmark:all //examples:all //src:all //tests:all
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang-$llvm_version -S . -B build -G "Ninja"
+          cmake --build build --config Release --target all
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang-$llvm_version -DENABLE_LOGGING=ON -S . -B build -G "Ninja"
+          cmake --build build --config Release --target all
           rustup override set nightly
           cargo run --manifest-path tools/Cargo.toml -p git-hooks -- check clang-format --source src benchmark tests examples --tool-version $llvm_version
           cargo run --manifest-path tools/Cargo.toml -p git-hooks -- check clang-tidy --source src benchmark examples --build build --tool-version $llvm_version --extra-arg="-I/usr/lib/llvm-$llvm_version/include/c++/v1/"
@@ -65,27 +63,32 @@ jobs:
           sudo bash scripts/install_llvm.sh $llvm_version
       - name: test
         run: |
-          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
-          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
-          mv $(bazel info bazel-testlogs)/tests/xyco_test_epoll/coverage.dat coverage_epoll.dat && mv $(bazel info bazel-testlogs)/tests/xyco_test_uring/coverage.dat coverage_uring.dat
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang-$llvm_version -DENABLE_LOGGING=ON -S . -B build -G "Ninja"
+          cmake --build build --config Release --target xyco_test_epoll xyco_test_uring
+          LLVM_PROFILE_FILE="build/tests/xyco_test_epoll.profraw" build/tests/xyco_test_epoll --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_epoll.profraw -o build/tests/xyco_test_epoll.profdata
+          llvm-cov-$llvm_version show build/tests/xyco_test_epoll -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_epoll.profdata > coverage_eopll.txt
+          LLVM_PROFILE_FILE="build/tests/xyco_test_uring.profraw" build/tests/xyco_test_uring --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_uring.profraw -o build/tests/xyco_test_uring.profdata
+          llvm-cov-$llvm_version show build/tests/xyco_test_uring -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_uring.profdata > coverage_uring.txt
       - name: upload epoll coverage report
         uses: codecov/codecov-action@v3
         with:
           flags: epoll
-          files: coverage_epoll.dat
+          files: coverage_epoll.txt
           fail_ci_if_error: true
           verbose: true
       - name: upload uring coverage report
         uses: codecov/codecov-action@v3
         with:
           flags: uring
-          files: coverage_uring.dat
+          files: coverage_uring.txt
           fail_ci_if_error: true
           verbose: true
       - name: upload tests coverage report
         uses: codecov/codecov-action@v3
         with:
           flags: tests
-          files: coverage_epoll.dat,coverage_uring.dat
+          files: coverage_epoll.txt,coverage_uring.txt
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -24,7 +24,7 @@ jobs:
           cmake --build build --config Release --target xyco_test_epoll xyco_test_uring
           LLVM_PROFILE_FILE="build/tests/xyco_test_epoll.profraw" build/tests/xyco_test_epoll --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_epoll.profraw -o build/tests/xyco_test_epoll.profdata
-          llvm-cov-$llvm_version show build/tests/xyco_test_epoll -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_epoll.profdata > coverage_eopll.txt
+          llvm-cov-$llvm_version show build/tests/xyco_test_epoll -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_epoll.profdata > coverage_epoll.txt
           LLVM_PROFILE_FILE="build/tests/xyco_test_uring.profraw" build/tests/xyco_test_uring --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_uring.profraw -o build/tests/xyco_test_uring.profdata
           llvm-cov-$llvm_version show build/tests/xyco_test_uring -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_uring.profdata > coverage_uring.txt

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -20,27 +20,32 @@ jobs:
           sudo bash scripts/install_llvm.sh $llvm_version
       - name: test
         run: |
-          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_epoll --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
-          bazel coverage --config=opt --config=coverage --config=enable_logging --test_output=all //tests:xyco_test_uring --test_arg=--gtest_repeat=100 --test_arg=--gtest_break_on_failure --test_arg=--gtest_shuffle --test_arg=--gtest_death_test_style=threadsafe
-          mv $(bazel info bazel-testlogs)/tests/xyco_test_epoll/coverage.dat coverage_epoll.dat && mv $(bazel info bazel-testlogs)/tests/xyco_test_uring/coverage.dat coverage_uring.dat
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_CXX_COMPILER=clang-$llvm_version -DENABLE_LOGGING=ON -S . -B build -G "Ninja"
+          cmake --build build --config Release --target xyco_test_epoll xyco_test_uring
+          LLVM_PROFILE_FILE="build/tests/xyco_test_epoll.profraw" build/tests/xyco_test_epoll --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_epoll.profraw -o build/tests/xyco_test_epoll.profdata
+          llvm-cov-$llvm_version show build/tests/xyco_test_epoll -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_epoll.profdata > coverage_eopll.txt
+          LLVM_PROFILE_FILE="build/tests/xyco_test_uring.profraw" build/tests/xyco_test_uring --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          llvm-profdata-$llvm_version merge -sparse build/tests/xyco_test_uring.profraw -o build/tests/xyco_test_uring.profdata
+          llvm-cov-$llvm_version show build/tests/xyco_test_uring -ignore-filename-regex=build -instr-profile=build/tests/xyco_test_uring.profdata > coverage_uring.txt
       - name: upload epoll coverage report
         uses: codecov/codecov-action@v3
         with:
           flags: epoll
-          files: coverage_epoll.dat
+          files: coverage_epoll.txt
           fail_ci_if_error: true
           verbose: true
       - name: upload uring coverage report
         uses: codecov/codecov-action@v3
         with:
           flags: uring
-          files: coverage_uring.dat
+          files: coverage_uring.txt
           fail_ci_if_error: true
           verbose: true
       - name: upload tests coverage report
         uses: codecov/codecov-action@v3
         with:
           flags: tests
-          files: coverage_epoll.dat,coverage_uring.dat
+          files: coverage_epoll.txt,coverage_uring.txt
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install essential packages
         run: |
-          sudo apt-get install -y lcov liburing-dev libboost-all-dev
+          sudo apt-get install -y ninja-build lcov liburing-dev libboost-all-dev
           sudo bash scripts/install_llvm.sh $llvm_version
       - name: test
         run: |

--- a/tests/fs/file.cc
+++ b/tests/fs/file.cc
@@ -198,6 +198,7 @@ TEST_F(FileTest, file_status) {
     CO_ASSERT_EQ(status.type(), std::filesystem::file_type::regular);
     CO_ASSERT_EQ(status.permissions(), std::filesystem::perms::others_read |
                                            std::filesystem::perms::group_read |
+                                           std::filesystem::perms::group_write |
                                            std::filesystem::perms::owner_read |
                                            std::filesystem::perms::owner_write);
   });

--- a/tests/fs/file.cc
+++ b/tests/fs/file.cc
@@ -191,16 +191,17 @@ TEST_F(FileTest, file_status) {
     const char *path = "test_file_status";
 
     auto file_path = (std::string(fs_root_).append(path));
-    auto file = (co_await xyco::fs::File::create(file_path)).unwrap();
+    auto file = (co_await xyco::fs::OpenOptions()
+                     .create(true)
+                     .write(true)
+                     .mode(0400)
+                     .open(file_path))
+                    .unwrap();
 
     auto status = (co_await file.status()).unwrap();
 
     CO_ASSERT_EQ(status.type(), std::filesystem::file_type::regular);
-    CO_ASSERT_EQ(status.permissions(), std::filesystem::perms::others_read |
-                                           std::filesystem::perms::group_read |
-                                           std::filesystem::perms::group_write |
-                                           std::filesystem::perms::owner_read |
-                                           std::filesystem::perms::owner_write);
+    CO_ASSERT_EQ(status.permissions(), std::filesystem::perms::owner_read);
   });
 }
 


### PR DESCRIPTION
# Summary
- Removes all Bazel related workflow steps and reverts to prior CMake build tool.

# Background
- Encounters weird error in the github workflow: `missing dependency declarations` for random rules with random files.