### PR TITLE
 [Refactor] Split up Runtime and RuntimeCtx

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ set(net_epoll_src "net/socket.cc" "net/epoll/listener.cc")
 set(net_uring_src "net/socket.cc" "net/io_uring/listener.cc")
 set(net_all_src "net/socket.cc" "net/epoll/listener.cc" "net/io_uring/listener.cc")
 
-set(runtime_src "runtime/blocking.cc" "runtime/driver.cc" "runtime/future.cc" "runtime/runtime.cc")
+set(runtime_src "runtime/blocking.cc" "runtime/driver.cc" "runtime/future.cc" "runtime/runtime.cc" "runtime/runtime_ctx.cc")
 
 set(time_src "time/driver.cc" "time/wheel.cc" "time/clock.cc")
 

--- a/src/fs/epoll/file.h
+++ b/src/fs/epoll/file.h
@@ -10,7 +10,7 @@
 #include "io/epoll/extra.h"
 #include "io/epoll/registry.h"
 #include "runtime/async_future.h"
-#include "runtime/runtime.h"
+#include "runtime/runtime_ctx.h"
 #include "utils/error.h"
 
 namespace xyco::fs::epoll {

--- a/src/fs/io_uring/file.h
+++ b/src/fs/io_uring/file.h
@@ -10,7 +10,7 @@
 #include "io/io_uring/extra.h"
 #include "io/io_uring/registry.h"
 #include "runtime/async_future.h"
-#include "runtime/runtime.h"
+#include "runtime/runtime_ctx.h"
 #include "utils/error.h"
 
 namespace xyco::fs::uring {

--- a/src/net/epoll/listener.h
+++ b/src/net/epoll/listener.h
@@ -7,7 +7,8 @@
 #include "io/epoll/registry.h"
 #include "io/utils.h"
 #include "net/socket.h"
-#include "runtime/runtime.h"
+#include "runtime/future.h"
+#include "runtime/runtime_ctx.h"
 #include "utils/error.h"
 
 namespace xyco::net::epoll {

--- a/src/net/io_uring/listener.h
+++ b/src/net/io_uring/listener.h
@@ -6,7 +6,7 @@
 #include "io/io_uring/extra.h"
 #include "io/io_uring/registry.h"
 #include "net/socket.h"
-#include "runtime/runtime.h"
+#include "runtime/runtime_ctx.h"
 
 namespace xyco::net::uring {
 class TcpStream;

--- a/src/runtime/async_future.h
+++ b/src/runtime/async_future.h
@@ -5,9 +5,8 @@
 #include <type_traits>
 
 #include "future.h"
-#include "poll.h"
-#include "runtime.h"
 #include "runtime/blocking.h"
+#include "runtime_ctx.h"
 
 namespace xyco::runtime {
 template <typename Fn>

--- a/src/runtime/driver.cc
+++ b/src/runtime/driver.cc
@@ -1,6 +1,6 @@
 #include "driver.h"
 
-#include "runtime.h"
+#include "runtime_ctx.h"
 
 auto xyco::runtime::Driver::poll() -> void {
   runtime::Events events;
@@ -16,7 +16,8 @@ auto xyco::runtime::Driver::poll() -> void {
 auto xyco::runtime::Driver::add_thread() -> void {
   local_registries_[std::this_thread::get_id()] = std::remove_reference_t<
       decltype(local_registries_[std::this_thread::get_id()])>();
+  auto* runtime = RuntimeCtx::get_ctx()->get_runtime();
   for (auto& registry_init : registry_initializers_) {
-    registry_init();
+    registry_init(runtime);
   }
 }

--- a/src/runtime/driver.h
+++ b/src/runtime/driver.h
@@ -8,6 +8,8 @@
 #include "registry.h"
 
 namespace xyco::runtime {
+class Runtime;
+
 class Driver {
  public:
   auto poll() -> void;
@@ -44,14 +46,14 @@ class Driver {
 
   auto add_thread() -> void;
 
-  Driver(std::vector<std::function<void()>>&& registry_initializers)
+  Driver(std::vector<std::function<void(Runtime*)>>&& registry_initializers)
       : registry_initializers_(std::move(registry_initializers)) {}
 
  private:
   constexpr static std::chrono::milliseconds MAX_TIMEOUT =
       std::chrono::milliseconds(2);
 
-  std::vector<std::function<void()>> registry_initializers_;
+  std::vector<std::function<void(Runtime*)>> registry_initializers_;
 
   std::unordered_map<std::thread::id,
                      std::unordered_map<decltype(typeid(int).hash_code()),

--- a/src/runtime/global_registry.h
+++ b/src/runtime/global_registry.h
@@ -4,7 +4,7 @@
 #include <gsl/pointers>
 #include <shared_mutex>
 
-#include "runtime/runtime.h"
+#include "runtime_ctx.h"
 
 namespace xyco::runtime {
 template <typename R>
@@ -30,7 +30,7 @@ class GlobalRegistry {
   }
 
  private:
-  static std::unordered_map<runtime::Runtime *, std::shared_ptr<R>>
+  static std::unordered_map<runtime::RuntimeBridge *, std::shared_ptr<R>>
       per_runtime_registry_;
   // Prevents runtime level data race, worker level multithread is serialized in
   // the runtime implementation.
@@ -39,7 +39,7 @@ class GlobalRegistry {
 
 template <typename R>
   requires(std::derived_from<R, Registry>)
-std::unordered_map<runtime::Runtime *, std::shared_ptr<R>>
+std::unordered_map<runtime::RuntimeBridge *, std::shared_ptr<R>>
     GlobalRegistry<R>::per_runtime_registry_;
 template <typename R>
   requires(std::derived_from<R, Registry>)

--- a/src/runtime/runtime_ctx.cc
+++ b/src/runtime/runtime_ctx.cc
@@ -1,0 +1,61 @@
+#include "runtime_ctx.h"
+
+#include "runtime.h"
+
+thread_local xyco::runtime::RuntimeBridge xyco::runtime::RuntimeCtx::runtime_ =
+    RuntimeBridge(nullptr);
+
+auto xyco::runtime::RuntimeBridge::register_future(FutureBase *future) -> void {
+  std::scoped_lock<std::mutex> lock_guard(runtime_->handle_mutex_);
+  runtime_->handles_.emplace(runtime_->handles_.begin(), future->get_handle(),
+                             future);
+}
+
+auto xyco::runtime::RuntimeBridge::driver() -> Driver & {
+  return runtime_->driver_;
+}
+
+auto xyco::runtime::RuntimeBridge::get_runtime() -> Runtime * {
+  return runtime_;
+}
+
+auto xyco::runtime::RuntimeBridge::wake(Events &events) -> void {
+  for (auto &event_ptr : events) {
+    TRACE("wake {}", *event_ptr);
+    auto *future = event_ptr->future_;
+    // Unbinds `future_` first to avoid contaminating the event's next coroutine
+    event_ptr->future_ = nullptr;
+    std::scoped_lock<std::mutex> lock_guard(runtime_->handle_mutex_);
+    runtime_->handles_.emplace(runtime_->handles_.begin(), future->get_handle(),
+                               future);
+  }
+  events.clear();
+}
+
+auto xyco::runtime::RuntimeBridge::wake_local(Events &events) -> void {
+  auto &worker = runtime_->workers_.find(std::this_thread::get_id())->second;
+  for (auto &event_ptr : events) {
+    TRACE("wake local {}", *event_ptr);
+    auto *future = event_ptr->future_;
+    event_ptr->future_ = nullptr;
+    std::scoped_lock<std::mutex> lock_guard(worker->handle_mutex_);
+    worker->handles_.emplace(worker->handles_.begin(), future->get_handle(),
+                             future);
+  }
+  events.clear();
+}
+
+xyco::runtime::RuntimeBridge::RuntimeBridge(Runtime *runtime)
+    : runtime_(runtime) {}
+
+auto xyco::runtime::RuntimeCtx::is_in_ctx() -> bool {
+  return runtime_.runtime_ != nullptr;
+}
+
+auto xyco::runtime::RuntimeCtx::set_ctx(Runtime *runtime) -> void {
+  runtime_ = RuntimeBridge(runtime);
+}
+
+auto xyco::runtime::RuntimeCtx::get_ctx() -> RuntimeBridge * {
+  return &runtime_;
+}

--- a/src/runtime/runtime_ctx.h
+++ b/src/runtime/runtime_ctx.h
@@ -1,0 +1,49 @@
+#ifndef XYCO_RUNTIME_RUNTIME_CTX_H_
+#define XYCO_RUNTIME_RUNTIME_CTX_H_
+
+#include "driver.h"
+#include "registry.h"
+
+namespace xyco::runtime {
+class Runtime;
+class Driver;
+
+class RuntimeBridge {
+  friend class RuntimeCtx;
+  friend class Driver;
+
+ public:
+  auto register_future(FutureBase *future) -> void;
+
+  auto driver() -> Driver &;
+
+  auto get_runtime() -> Runtime *;
+
+ private:
+  auto wake(Events &events) -> void;
+
+  auto wake_local(Events &events) -> void;
+
+  RuntimeBridge(Runtime *runtime);
+
+  Runtime *runtime_;
+};
+
+// This class is mainly used for library inner interaction with `Runtime`. So
+// it's an useful interface for expert users who neeeds to extend the library,
+// like writing custom-made `Registry`. For major library callers, use `Runtime`
+// and interact with it via its `spawn` interface.
+class RuntimeCtx {
+ public:
+  static auto is_in_ctx() -> bool;
+
+  static auto set_ctx(Runtime *runtime) -> void;
+
+  static auto get_ctx() -> RuntimeBridge *;
+
+ private:
+  thread_local static RuntimeBridge runtime_;
+};
+}  // namespace xyco::runtime
+
+#endif  // XYCO_RUNTIME_RUNTIME_CTX_H_

--- a/src/runtime/utils/join.h
+++ b/src/runtime/utils/join.h
@@ -4,6 +4,7 @@
 #include <mutex>
 
 #include "runtime/runtime.h"
+#include "runtime/runtime_ctx.h"
 #include "type_wrapper.h"
 
 namespace xyco::runtime {
@@ -15,8 +16,10 @@ class JoinFuture : public Future<std::pair<TypeWrapper<T1>, TypeWrapper<T2>>> {
   auto poll(Handle<void> self) -> Poll<CoOutput> override {
     if (!ready_) {
       ready_ = true;
-      RuntimeCtx::get_ctx()->spawn(future_wrapper<T1, 0>(std::move(future1_)));
-      RuntimeCtx::get_ctx()->spawn(future_wrapper<T2, 1>(std::move(future2_)));
+      RuntimeCtx::get_ctx()->get_runtime()->spawn(
+          future_wrapper<T1, 0>(std::move(future1_)));
+      RuntimeCtx::get_ctx()->get_runtime()->spawn(
+          future_wrapper<T2, 1>(std::move(future2_)));
       return Pending();
     }
 

--- a/src/runtime/utils/select.h
+++ b/src/runtime/utils/select.h
@@ -2,6 +2,7 @@
 #define XYCO_RUNTIME_UTILS_SELECT_H
 
 #include "runtime/runtime.h"
+#include "runtime/runtime_ctx.h"
 #include "type_wrapper.h"
 
 namespace xyco::runtime {
@@ -18,8 +19,8 @@ class SelectFuture
           future_wrapper<T1, 1>(std::move(futures_.first)),
           future_wrapper<T2, 2>(std::move(futures_.second)));
       wrappers_ = {wrapper1.get_handle(), wrapper2.get_handle()};
-      RuntimeCtx::get_ctx()->spawn(std::move(wrapper1));
-      RuntimeCtx::get_ctx()->spawn(std::move(wrapper2));
+      RuntimeCtx::get_ctx()->get_runtime()->spawn(std::move(wrapper1));
+      RuntimeCtx::get_ctx()->get_runtime()->spawn(std::move(wrapper2));
       return Pending();
     }
 

--- a/src/sync/mpsc.h
+++ b/src/sync/mpsc.h
@@ -3,7 +3,8 @@
 
 #include <queue>
 
-#include "runtime/runtime.h"
+#include "runtime/future.h"
+#include "runtime/runtime_ctx.h"
 
 namespace xyco::sync::mpsc {
 template <typename Value, size_t Size>

--- a/src/sync/oneshot.h
+++ b/src/sync/oneshot.h
@@ -1,7 +1,8 @@
 #ifndef XYCO_SYNC_ONESHOT_H
 #define XYCO_SYNC_ONESHOT_H
 
-#include "runtime/runtime.h"
+#include "runtime/future.h"
+#include "runtime/runtime_ctx.h"
 
 namespace xyco::sync::oneshot {
 template <typename Value>

--- a/src/time/sleep.h
+++ b/src/time/sleep.h
@@ -2,7 +2,8 @@
 #define XYCO_TIME_SLEEP_H
 
 #include "clock.h"
-#include "runtime/runtime.h"
+#include "runtime/future.h"
+#include "runtime/runtime_ctx.h"
 #include "time/driver.h"
 
 namespace xyco::time {


### PR DESCRIPTION
# Background
Current `Runtime` is a motley interface contains both methods for library callers like `spawn` and methods for inhouse `Registry` communication like `driver`. So isolating the two parts provides cleaner public interface to library callers and also surmounts an obstacle for sorting out module dependent relationship.

# Feature
Splits up `Runtime` and `RuntimeCtx` into different compilation units, one for public interface and another acts as the inner bridge between `Registry` and `Runtime`.