### PR TITLE
[Fix] Fix epoll echo server crash

### DIFF
--- a/src/io/epoll/registry.cc
+++ b/src/io/epoll/registry.cc
@@ -111,6 +111,7 @@ auto xyco::io::epoll::IoRegistryImpl::deregister(
   }
 
   {
+    std::scoped_lock<std::mutex> lock_guard(events_mutex_);
     auto event_it =
         std::find(registered_events_.begin(), registered_events_.end(), event);
     if (event_it != registered_events_.end()) {

--- a/src/runtime/global_registry.h
+++ b/src/runtime/global_registry.h
@@ -13,7 +13,8 @@ class GlobalRegistry {
  public:
   template <typename... Args>
   static auto get_instance(Args... args) -> std::shared_ptr<R> {
-    auto current_runtime = gsl::make_not_null(runtime::RuntimeCtx::get_ctx());
+    auto current_runtime =
+        gsl::make_not_null(runtime::RuntimeCtx::get_ctx()->get_runtime());
     {
       std::shared_lock<std::shared_mutex> lock_guard(runtime_mutex_);
       if (per_runtime_registry_.contains(current_runtime)) {
@@ -30,7 +31,7 @@ class GlobalRegistry {
   }
 
  private:
-  static std::unordered_map<runtime::RuntimeBridge *, std::shared_ptr<R>>
+  static std::unordered_map<runtime::Runtime *, std::shared_ptr<R>>
       per_runtime_registry_;
   // Prevents runtime level data race, worker level multithread is serialized in
   // the runtime implementation.
@@ -39,7 +40,7 @@ class GlobalRegistry {
 
 template <typename R>
   requires(std::derived_from<R, Registry>)
-std::unordered_map<runtime::RuntimeBridge *, std::shared_ptr<R>>
+std::unordered_map<runtime::Runtime *, std::shared_ptr<R>>
     GlobalRegistry<R>::per_runtime_registry_;
 template <typename R>
   requires(std::derived_from<R, Registry>)


### PR DESCRIPTION
# Crash behavior
Random segment fault or `epoll_ctl` syscall errors.
# Root Cause
- `RuntimeBridge` is consturcted per thread so it has different virtual address in every thread, and ultimately leads to many live epoll instances.
- Concurrent r/w to the private member `registered_events_` misses lock protection.