### PR TITLE
[Opt] Separate block registry from runtime

### DIFF
--- a/benchmark/echo_server.cc
+++ b/benchmark/echo_server.cc
@@ -2,6 +2,7 @@
 #include "io/registry.h"
 #include "io/write.h"
 #include "net/listener.h"
+#include "runtime/blocking.h"
 #include "runtime/runtime.h"
 
 class Server {
@@ -51,7 +52,7 @@ auto main() -> int {
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto server = Server(xyco::runtime::Builder::new_multi_thread()
                            .worker_threads(2)
-                           .max_blocking_threads(2)
+                           .registry<xyco::runtime::BlockingRegistry>(2)
                            .registry<xyco::io::IoRegistry>(4)
                            .build()
                            .unwrap(),

--- a/examples/http_server.cc
+++ b/examples/http_server.cc
@@ -6,6 +6,7 @@
 #include "io/registry.h"
 #include "io/write.h"
 #include "net/listener.h"
+#include "runtime/blocking.h"
 #include "runtime/runtime.h"
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
@@ -237,7 +238,7 @@ auto main() -> int {
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto server = Server(xyco::runtime::Builder::new_multi_thread()
                            .worker_threads(1)
-                           .max_blocking_threads(1)
+                           .registry<xyco::runtime::BlockingRegistry>(1)
                            .registry<xyco::io::IoRegistry>(4)
                            .build()
                            .unwrap(),

--- a/src/main.cc
+++ b/src/main.cc
@@ -2,6 +2,7 @@
 #include "io/registry.h"
 #include "io/write.h"
 #include "net/listener.h"
+#include "runtime/blocking.h"
 #include "runtime/runtime.h"
 
 using xyco::runtime::Future;
@@ -57,7 +58,7 @@ auto main(int /*unused*/, char** /*unused*/) -> int {
 
   auto runtime = xyco::runtime::Builder::new_multi_thread()
                      .worker_threads(2)
-                     .max_blocking_threads(2)
+                     .registry<xyco::runtime::BlockingRegistry>(2)
                      .registry<xyco::io::IoRegistry>(4)
                      .build()
                      .unwrap();

--- a/src/runtime/future.h
+++ b/src/runtime/future.h
@@ -11,7 +11,6 @@
 #include "boost/stacktrace.hpp"
 
 namespace xyco::runtime {
-class Runtime;
 class FutureBase;
 template <typename Output>
 class Future;

--- a/src/runtime/mod.h
+++ b/src/runtime/mod.h
@@ -1,6 +1,0 @@
-#ifndef XYCO_RUNTIME_MOD_H_
-#define XYCO_RUNTIME_MOD_H_
-
-#include "future.h"
-
-#endif  // XYCO_RUNTIME_MOD_H_

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -2,7 +2,7 @@
 
 #include <gsl/pointers>
 
-#include "runtime/blocking.h"
+#include "runtime_ctx.h"
 
 auto xyco::runtime::Worker::lanuch(Runtime *runtime) -> void {
   ctx_ = std::thread([this, runtime]() {
@@ -116,11 +116,6 @@ auto xyco::runtime::Builder::new_multi_thread() -> Builder {
 
 auto xyco::runtime::Builder::worker_threads(uintptr_t val) -> Builder & {
   worker_num_ = val;
-  return *this;
-}
-
-auto xyco::runtime::Builder::max_blocking_threads(uintptr_t val) -> Builder & {
-  registry<BlockingRegistry>(val);
   return *this;
 }
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -55,17 +55,6 @@ class Runtime {
     }
   }
 
-  template <typename Fn>
-  auto spawn_blocking(Fn function) -> void
-    requires(std::is_invocable_v<Fn>)
-  {
-    using Return = decltype(function());
-
-    spawn([=]() -> Future<Return> {
-      co_return co_await AsyncFuture<Return>([=]() { return function(); });
-    }());
-  }
-
   Runtime(Privater priv,
           std::vector<std::function<void(Runtime *)>> &&registry_initializers);
 
@@ -136,8 +125,6 @@ class Builder {
   static auto new_multi_thread() -> Builder;
 
   auto worker_threads(uintptr_t val) -> Builder &;
-
-  auto max_blocking_threads(uintptr_t val) -> Builder &;
 
   template <typename Registry, typename... Args>
   auto registry(Args... args) -> Builder & {

--- a/tests/common/utils.cc
+++ b/tests/common/utils.cc
@@ -1,6 +1,7 @@
 #include "utils.h"
 
 #include "io/registry.h"
+#include "runtime/blocking.h"
 #include "time/driver.h"
 
 std::unique_ptr<xyco::runtime::Runtime> TestRuntimeCtx::runtime_;
@@ -23,7 +24,7 @@ TestRuntimeCtxGuard::~TestRuntimeCtxGuard() {
 auto TestRuntimeCtx::init() -> void {
   runtime_ = xyco::runtime::Builder::new_multi_thread()
                  .worker_threads(1)
-                 .max_blocking_threads(1)
+                 .registry<xyco::runtime::BlockingRegistry>(1)
                  .registry<xyco::io::IoRegistry>(4)
                  .registry<xyco::time::TimeRegistry>()
                  .on_worker_start([]() {})

--- a/tests/runtime/future.cc
+++ b/tests/runtime/future.cc
@@ -2,6 +2,7 @@
 
 #include <gsl/pointers>
 
+#include "runtime/blocking.h"
 #include "utils.h"
 
 class InRuntimeTest : public ::testing::Test {
@@ -104,7 +105,7 @@ TEST(RuntimeDeathTest, terminate) {
 
         auto runtime = xyco::runtime::Builder::new_multi_thread()
                            .worker_threads(1)
-                           .max_blocking_threads(1)
+                           .registry<xyco::runtime::BlockingRegistry>(1)
                            .build()
                            .unwrap();
 
@@ -128,7 +129,7 @@ TEST(RuntimeDeathTest, coroutine_exception) {
         {
           auto runtime = xyco::runtime::Builder::new_multi_thread()
                              .worker_threads(2)
-                             .max_blocking_threads(1)
+                             .registry<xyco::runtime::BlockingRegistry>(1)
                              .build()
                              .unwrap();
 
@@ -198,7 +199,7 @@ TEST(RuntimeDeathTest, drop_parameter) {
         {
           auto runtime = xyco::runtime::Builder::new_multi_thread()
                              .worker_threads(1)
-                             .max_blocking_threads(1)
+                             .registry<xyco::runtime::BlockingRegistry>(1)
                              .build()
                              .unwrap();
 


### PR DESCRIPTION
# Overview
Separate block registry from runtime to simplify core loop of runtime and extend customizable ability.