### PR TITLE
[Feat] in-place worker with block_on interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
         run: |
           BINARY_DIR=build/enable_logging/tests
           LLVM_VERSION=$llvm_version cmake --workflow --preset ci_test
-          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_epoll.profraw" $BINARY_DIR/xyco_test_epoll --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_epoll.profraw" $BINARY_DIR/xyco_test_epoll --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse $BINARY_DIR/xyco_test_epoll.profraw -o $BINARY_DIR/xyco_test_epoll.profdata
           llvm-cov-$llvm_version show $BINARY_DIR/xyco_test_epoll -ignore-filename-regex=build -instr-profile=$BINARY_DIR/xyco_test_epoll.profdata > coverage_epoll.txt
-          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_uring.profraw" $BINARY_DIR/xyco_test_uring --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_uring.profraw" $BINARY_DIR/xyco_test_uring --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse $BINARY_DIR/xyco_test_uring.profraw -o $BINARY_DIR/xyco_test_uring.profdata
           llvm-cov-$llvm_version show $BINARY_DIR/xyco_test_uring -ignore-filename-regex=build -instr-profile=$BINARY_DIR/xyco_test_uring.profdata > coverage_uring.txt
       - name: upload epoll coverage report

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           BINARY_DIR=build/enable_logging/tests
           LLVM_VERSION=$llvm_version cmake --workflow --preset ci_test
-          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_epoll.profraw" $BINARY_DIR/xyco_test_epoll --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_epoll.profraw" $BINARY_DIR/xyco_test_epoll --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse $BINARY_DIR/xyco_test_epoll.profraw -o $BINARY_DIR/xyco_test_epoll.profdata
           llvm-cov-$llvm_version show $BINARY_DIR/xyco_test_epoll -ignore-filename-regex=build -instr-profile=$BINARY_DIR/xyco_test_epoll.profdata > coverage_epoll.txt
-          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_uring.profraw" $BINARY_DIR/xyco_test_uring --gtest_repeat=100 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+          LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_uring.profraw" $BINARY_DIR/xyco_test_uring --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
           llvm-profdata-$llvm_version merge -sparse $BINARY_DIR/xyco_test_uring.profraw -o $BINARY_DIR/xyco_test_uring.profdata
           llvm-cov-$llvm_version show $BINARY_DIR/xyco_test_uring -ignore-filename-regex=build -instr-profile=$BINARY_DIR/xyco_test_uring.profdata > coverage_uring.txt
       - name: upload epoll coverage report

--- a/examples/http_server.cc
+++ b/examples/http_server.cc
@@ -94,15 +94,15 @@ class StatusLine {
 class Server {
  public:
   Server(std::unique_ptr<xyco::runtime::Runtime> runtime, uint16_t port)
-      : runtime_(std::move(runtime)) {
-    runtime_->spawn(init_server(port));
-  }
+      : runtime_(std::move(runtime)), port_(port) {}
+
+  auto run() -> void { runtime_->block_on(init_server()); }
 
  private:
-  auto init_server(uint16_t port) -> xyco::runtime::Future<void> {
+  auto init_server() -> xyco::runtime::Future<void> {
     auto tcp_socket = *xyco::net::TcpSocket::new_v4();
     *tcp_socket.set_reuseaddr(true);
-    *co_await tcp_socket.bind(xyco::net::SocketAddr::new_v4({}, port));
+    *co_await tcp_socket.bind(xyco::net::SocketAddr::new_v4({}, port_));
     auto listener = *co_await tcp_socket.listen(LISTEN_BACKLOG);
 
     while (true) {
@@ -216,6 +216,7 @@ class Server {
   }
 
   std::unique_ptr<xyco::runtime::Runtime> runtime_;
+  int port_;
 
   static constexpr int LISTEN_BACKLOG = 5000;
 };
@@ -224,15 +225,11 @@ class Server {
 auto main() -> int {
   constexpr uint16_t port = 8080;
 
-  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto server = Server(*xyco::runtime::Builder::new_multi_thread()
                             .worker_threads(1)
                             .registry<xyco::task::BlockingRegistry>(1)
                             .registry<xyco::io::IoRegistry>(4)
                             .build(),
                        port);
-
-  while (true) {
-    std::this_thread::sleep_for(std::chrono::seconds(3));
-  }
+  server.run();
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -64,9 +64,7 @@ auto main(int /*unused*/, char** /*unused*/) -> int {
   runtime->spawn(start_server());
   // ensure server prepared to accept new connections
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  runtime->spawn(start_client());
-  runtime->spawn(start_client());
-  runtime->spawn(start_client());
-
-  std::this_thread::sleep_for(wait_seconds);
+  for (auto i = 0; i < 3; i++) {
+    runtime->block_on(start_client());
+  }
 }

--- a/src/net/epoll/listener.cc
+++ b/src/net/epoll/listener.cc
@@ -39,10 +39,7 @@ auto xyco::net::epoll::TcpSocket::connect(SocketAddr addr)
               runtime::Event{.future_ = this,
                              .extra_ = std::make_unique<io::epoll::IoExtra>(
                                  io::epoll::IoExtra::Interest::Write,
-                                 socket_->into_c_fd())})) {
-      runtime::RuntimeCtx::get_ctx()->driver().Register<io::epoll::IoRegistry>(
-          event_);
-    }
+                                 socket_->into_c_fd())})) {}
 
     auto poll(runtime::Handle<void> self) -> runtime::Poll<CoOutput> override {
       auto *extra = dynamic_cast<io::epoll::IoExtra *>(event_->extra_.get());
@@ -68,9 +65,8 @@ auto xyco::net::epoll::TcpSocket::connect(SocketAddr addr)
             extra->state_.get_field<io::epoll::IoExtra::State::Readable>())};
       }
       event_->future_ = this;
-      runtime::RuntimeCtx::get_ctx()
-          ->driver()
-          .reregister<io::epoll::IoRegistry>(event_);
+      runtime::RuntimeCtx::get_ctx()->driver().Register<io::epoll::IoRegistry>(
+          event_);
       return runtime::Pending();
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   net/tcp.cc
   runtime/future.cc
   runtime/join.cc
+  runtime/runtime.cc
   runtime/select.cc
   sync/mpsc.cc
   sync/oneshot.cc
@@ -58,6 +59,7 @@ add_executable(
   net/tcp.cc
   runtime/future.cc
   runtime/join.cc
+  runtime/runtime.cc
   runtime/select.cc
   sync/mpsc.cc
   sync/oneshot.cc

--- a/tests/runtime/runtime.cc
+++ b/tests/runtime/runtime.cc
@@ -1,0 +1,20 @@
+#include "xyco/runtime/runtime.h"
+
+#include <gtest/gtest.h>
+
+class RuntimeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    runtime_ =
+        *xyco::runtime::Builder::new_multi_thread().worker_threads(1).build();
+  }
+
+  static std::unique_ptr<xyco::runtime::Runtime> runtime_;
+};
+
+std::unique_ptr<xyco::runtime::Runtime> RuntimeTest::runtime_;
+
+TEST_F(RuntimeTest, block_on) {
+  runtime_->block_on([]() -> xyco::runtime::Future<void> { co_return; }());
+  runtime_->block_on([]() -> xyco::runtime::Future<int> { co_return 1; }());
+}


### PR DESCRIPTION
1. Allow to block the current thread to execute some async tasks, a practical feature to build a channel across async and sync boundary.

    Now the `block_on` interface has some cons:
    - Strict limitation on the blocked thread: not a worker of any runtime instance and only where the runtime instance created.
    - Cannot return the result of the async task from runtime to the sync world.
2. Cancel repeated running of unit test to improve time cost.