### PR TITLE
[Opt] upgrade spdlog to 1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,13 @@ FetchContent_Declare(
   URL_HASH
     SHA256=f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9)
 FetchContent_MakeAvailable(GSL)
+
+set(SPDLOG_USE_STD_FORMAT ON)
 FetchContent_Declare(
   spdlog
-  URL "https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"
+  URL "https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"
   URL_HASH
-    SHA256=697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224)
+    SHA256=4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9)
 FetchContent_MakeAvailable(spdlog)
 
 find_package(Boost REQUIRED)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-# syntax=docker/dockerfile:1
-FROM ddxy18/dev-env:latest
-
-SHELL ["zsh", "-c"]
-# install liburing
-RUN apt-get install -y liburing-dev \
-    && cd $HOME && git clone https://github.com/ddxy18/xyco.git && cd xyco && scripts/setup.sh
-
-CMD [ "zsh" ]

--- a/include/xyco/time/driver.h
+++ b/include/xyco/time/driver.h
@@ -1,7 +1,5 @@
-#ifndef XYCO_TIME_DRIVER_H
-#define XYCO_TIME_DRIVER_H
-
-#include <iomanip>
+#ifndef XYCO_TIME_DRIVER_H_
+#define XYCO_TIME_DRIVER_H_
 
 #include "xyco/runtime/global_registry.h"
 #include "xyco/time/wheel.h"
@@ -47,16 +45,10 @@ struct std::formatter<xyco::time::TimeExtra>
   template <typename FormatContext>
   auto format(const xyco::time::TimeExtra &extra, FormatContext &ctx) const
       -> decltype(ctx.out()) {
-    // FIXME(xiaoyu): Replaced with `std::format` after libc++ implementation of
-    // `std::formatter<std::chrono::sys_time>` is available.
-    auto time_t_time = std::chrono::system_clock::to_time_t(extra.expire_time_);
-    // NOLINTNEXTLINE(concurrency-mt-unsafe)
-    auto *tm_time = std::localtime(&time_t_time);
-    std::stringstream stream;
-    stream << std::put_time(tm_time, "%F %T");
-    return std::format_to(ctx.out(), "TimeExtra{{expire_time_={}}}",
-                          stream.str());
+    return std::format_to(
+        ctx.out(), "TimeExtra{{expire_time_={:%F %T}}}",
+        std::chrono::round<std::chrono::seconds>(extra.expire_time_));
   }
 };
 
-#endif  // XYCO_TIME_DRIVER_H
+#endif  // XYCO_TIME_DRIVER_H_


### PR DESCRIPTION
- Upgrade spdlog to latest version to get rid of fmt, a format dependency which can be substituted with C+20 formatting library.
- Remove configs of the deprecated docker based dev environment.