### PR TITLE
[Refactor] Decouple core parts of runtime

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,4 +7,4 @@
 #
 # To enable this hook, rename this file to "pre-commit".
 
-find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics --dry-run --verbose
+find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics -i --verbose

--- a/.githooks/pre-rebase
+++ b/.githooks/pre-rebase
@@ -15,4 +15,4 @@
 # merged to 'next' branch from getting rebased, because allowing it
 # would result in rebasing already published history.
 
-find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics --dry-run --verbose
+find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics -i --verbose

--- a/include/xyco/runtime/driver.h
+++ b/include/xyco/runtime/driver.h
@@ -8,8 +8,6 @@
 #include "xyco/runtime/registry.h"
 
 namespace xyco::runtime {
-class Runtime;
-
 class Driver {
  public:
   auto poll() -> void;
@@ -43,14 +41,14 @@ class Driver {
 
   auto add_thread() -> void;
 
-  Driver(std::vector<std::function<void(Runtime*)>>&& registry_initializers)
+  Driver(std::vector<std::function<void(Driver*)>>&& registry_initializers)
       : registry_initializers_(std::move(registry_initializers)) {}
 
  private:
   constexpr static std::chrono::milliseconds MAX_TIMEOUT =
       std::chrono::milliseconds(2);
 
-  std::vector<std::function<void(Runtime*)>> registry_initializers_;
+  std::vector<std::function<void(Driver*)>> registry_initializers_;
 
   std::unordered_map<std::thread::id,
                      std::unordered_map<decltype(typeid(int).hash_code()),

--- a/include/xyco/runtime/runtime.h
+++ b/include/xyco/runtime/runtime.h
@@ -89,7 +89,7 @@ class Runtime {
   }
 
   Runtime(Privater priv,
-          std::vector<std::function<void(Runtime *)>> &&registry_initializers);
+          std::vector<std::function<void(Driver *)>> &&registry_initializers);
 
   Runtime(const Runtime &runtime) = delete;
 
@@ -171,9 +171,8 @@ class Builder {
 
   template <typename Registry, typename... Args>
   auto registry(Args... args) -> Builder & {
-    registry_initializers_.push_back([=](Runtime *runtime) {
-      runtime->driver_.add_registry<Registry>(args...);
-    });
+    registry_initializers_.push_back(
+        [=](Driver *driver) { driver->add_registry<Registry>(args...); });
     return *this;
   }
 
@@ -191,7 +190,7 @@ class Builder {
   auto (*on_start_f_)() -> void{};
   auto (*on_stop_f_)() -> void{};
 
-  std::vector<std::function<void(Runtime *)>> registry_initializers_;
+  std::vector<std::function<void(Driver *)>> registry_initializers_;
 };
 }  // namespace xyco::runtime
 

--- a/include/xyco/runtime/runtime.h
+++ b/include/xyco/runtime/runtime.h
@@ -50,8 +50,6 @@ class Runtime {
   friend class Builder;
   friend class RuntimeBridge;
 
-  class Privater {};
-
  public:
   template <typename T>
   auto spawn(Future<T> future) -> void {
@@ -88,8 +86,8 @@ class Runtime {
     in_place_worker_.run_in_place(this);
   }
 
-  Runtime(Privater priv,
-          std::vector<std::function<void(Driver *)>> &&registry_initializers);
+  Runtime(std::vector<std::function<void(Driver *)>> &&registry_initializers,
+          int worker_num);
 
   Runtime(const Runtime &runtime) = delete;
 
@@ -158,9 +156,6 @@ class Runtime {
   std::atomic_int init_worker_num_;
   std::mutex worker_launch_mutex_;
   std::condition_variable worker_launch_cv_;
-
-  auto (*on_start_f_)() -> void{};
-  auto (*on_stop_f_)() -> void{};
 };
 
 class Builder {
@@ -176,19 +171,11 @@ class Builder {
     return *this;
   }
 
-  auto on_worker_start(auto (*function)()->void) -> Builder &;
-
-  auto on_worker_stop(auto (*function)()->void) -> Builder &;
-
-  [[nodiscard]] auto build() -> utils::Result<std::unique_ptr<Runtime>>;
+  [[nodiscard]] auto build()
+      -> std::expected<std::unique_ptr<Runtime>, std::nullptr_t>;
 
  private:
-  static auto default_f() -> void;
-
   uintptr_t worker_num_{};
-
-  auto (*on_start_f_)() -> void{};
-  auto (*on_stop_f_)() -> void{};
 
   std::vector<std::function<void(Driver *)>> registry_initializers_;
 };

--- a/src/runtime/driver.cc
+++ b/src/runtime/driver.cc
@@ -16,8 +16,7 @@ auto xyco::runtime::Driver::poll() -> void {
 auto xyco::runtime::Driver::add_thread() -> void {
   local_registries_[std::this_thread::get_id()] = std::remove_reference_t<
       decltype(local_registries_[std::this_thread::get_id()])>();
-  auto* runtime = RuntimeCtx::get_ctx()->get_runtime();
   for (auto& registry_init : registry_initializers_) {
-    registry_init(runtime);
+    registry_init(this);
   }
 }

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -107,7 +107,7 @@ auto xyco::runtime::Worker::run_loop_once(Runtime *runtime) -> void {
 
 xyco::runtime::Runtime::Runtime(
     [[maybe_unused]] Privater priv,
-    std::vector<std::function<void(Runtime *)>> &&registry_initializers)
+    std::vector<std::function<void(Driver *)>> &&registry_initializers)
     : driver_(std::move(registry_initializers)) {}
 
 xyco::runtime::Runtime::~Runtime() {

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -1,55 +1,65 @@
 #include "xyco/runtime/runtime.h"
 
-#include <gsl/pointers>
+#include <ranges>
 
 #include "xyco/runtime/runtime_ctx.h"
 
-auto xyco::runtime::Worker::run_in_new_thread(Runtime *runtime) -> void {
-  ctx_ = std::thread([this, runtime]() {
-    init_in_thread(runtime);
-
-    run_in_place(runtime);
-
-    std::unique_lock<std::mutex> lock_guard(runtime->idle_workers_mutex_);
-    runtime->idle_workers_.push_back(std::this_thread::get_id());
-  });
-}
-
 auto xyco::runtime::Worker::run_in_place(Runtime *runtime) -> void {
-  end_ = false;
-  while (!end_) {
+  while (!suspend_flag_) {
     run_loop_once(runtime);
   }
+  suspend_flag_ = false;
 }
 
-auto xyco::runtime::Worker::init_in_thread(Runtime *runtime) -> void {
-  RuntimeCtx::set_ctx(runtime);
+auto xyco::runtime::Worker::suspend() -> void { suspend_flag_ = true; }
 
-  // Workers have to add local registry to `Driver` and this modifies non
-  // thread safe container in `Driver`. The container is read only after all
-  // initializing completes. So wait until all workers complete initializing
-  // to avoid concurrent write and read.
-  std::unique_lock<std::mutex> worker_init_lock_guard(
-      runtime->worker_launch_mutex_);
-  runtime->driver_.add_thread();
-  // Count in-place worker
-  auto worker_count = static_cast<int>(runtime->worker_num_ + 1);
-  if (++runtime->init_worker_num_ == worker_count) {
-    worker_init_lock_guard.unlock();
-    runtime->worker_launch_cv_.notify_all();
-  } else {
-    runtime->worker_launch_cv_.wait(worker_init_lock_guard);
-  }
-}
-
-auto xyco::runtime::Worker::stop() -> void { end_ = true; }
-
-auto xyco::runtime::Worker::get_native_id() const -> std::thread::id {
+auto xyco::runtime::Worker::id() const -> std::thread::id {
   return ctx_.get_id();
 }
 
+xyco::runtime::Worker::Worker(Runtime *runtime, bool in_place) {
+  if (in_place) {
+    init_in_thread(runtime, true);
+  } else {
+    ctx_ = std::thread([this, runtime]() {
+      init_in_thread(runtime);
+      run_in_place(runtime);
+    });
+  }
+}
+
+xyco::runtime::Worker::~Worker() {
+  if (ctx_.joinable()) {
+    ctx_.join();
+  }
+}
+
+auto xyco::runtime::Worker::init_in_thread(Runtime *runtime, bool in_place)
+    -> void {
+  RuntimeCtx::set_ctx(runtime);
+
+  if (in_place) {
+    runtime->driver_.add_thread();
+  } else {
+    // Workers have to add local registry to `Driver` and this modifies non
+    // thread safe container in `Driver`. The container is read only after all
+    // initializing completes. So wait until all workers complete initializing
+    // to avoid concurrent write and read.
+    std::unique_lock<std::mutex> worker_init_lock_guard(
+        runtime->worker_launch_mutex_);
+    runtime->driver_.add_thread();
+
+    if (++runtime->init_worker_num_ == runtime->worker_num_) {
+      worker_init_lock_guard.unlock();
+      runtime->worker_launch_cv_.notify_all();
+    } else {
+      runtime->worker_launch_cv_.wait(worker_init_lock_guard);
+    }
+  }
+}
+
 auto xyco::runtime::Worker::run_loop_once(Runtime *runtime) -> void {
-  auto resume = [&end = end_](auto &handles, auto &handle_mutex) {
+  auto resume = [&end = suspend_flag_](auto &handles, auto &handle_mutex) {
     std::unique_lock<std::mutex> lock_guard(handle_mutex, std::try_to_lock);
     if (!lock_guard) {
       return;
@@ -68,65 +78,41 @@ auto xyco::runtime::Worker::run_loop_once(Runtime *runtime) -> void {
 
   // resume local future
   resume(handles_, handle_mutex_);
-  if (end_) {
+  if (suspend_flag_) {
     return;
   }
   // resume global future
   resume(runtime->handles_, runtime->handle_mutex_);
-  if (end_) {
+  if (suspend_flag_) {
     return;
   }
 
   // drive both local and global registry
   runtime->driver_.poll();
-
-  // try to clear idle workers
-  {
-    // try to lock strategy to avoid deadlock in situation:
-    // ~Runtime owns the lock before current thread
-    std::unique_lock<std::mutex> worker_lock_guard(runtime->worker_mutex_,
-                                                   std::try_to_lock);
-    if (!worker_lock_guard) {
-      return;
-    }
-
-    std::scoped_lock<std::mutex> idle_worker_lock_guard(
-        runtime->idle_workers_mutex_);
-    for (auto &tid : runtime->idle_workers_) {
-      auto pos = runtime->workers_.find(tid);
-      if (pos != std::end(runtime->workers_)) {
-        pos->second->ctx_.join();
-        runtime->workers_.erase(pos);
-      }
-    }
-    runtime->idle_workers_.clear();
-  }
 }
 
 xyco::runtime::Runtime::Runtime(
     std::vector<std::function<void(Driver *)>> &&registry_initializers,
-    int worker_num)
-    : driver_(std::move(registry_initializers)), worker_num_(worker_num) {
-  for (auto i = 0; i < worker_num; i++) {
-    auto worker = std::make_unique<Worker>();
-    worker->run_in_new_thread(this);
-    workers_.emplace(worker->get_native_id(), std::move(worker));
+    uint16_t worker_num)
+    : driver_(std::move(registry_initializers)),
+      worker_num_(worker_num),
+      in_place_worker_(this, true) {
+  for ([[maybe_unused]] auto idx :
+       std::views::iota(0, static_cast<int>(worker_num_))) {
+    auto worker = std::make_unique<Worker>(this);
+    workers_.emplace(worker->id(), std::move(worker));
   }
-  // initialized last to avoid blocking other workers
-  in_place_worker_.init_in_thread(this);
 }
 
 xyco::runtime::Runtime::~Runtime() {
-  std::unique_lock<std::mutex> lock_guard_(worker_mutex_);
-  for (const auto &[tid, worker] : workers_) {
-    worker->stop();
-    worker->ctx_.join();
+  for (const auto &[_, worker] : workers_) {
+    worker->suspend();
   }
 }
 
 auto xyco::runtime::Builder::new_multi_thread() -> Builder { return {}; }
 
-auto xyco::runtime::Builder::worker_threads(uintptr_t val) -> Builder & {
+auto xyco::runtime::Builder::worker_threads(uint16_t val) -> Builder & {
   worker_num_ = val;
   return *this;
 }

--- a/tests/common/utils.cc
+++ b/tests/common/utils.cc
@@ -12,7 +12,5 @@ auto TestRuntimeCtx::init() -> void {
                   .registry<xyco::task::BlockingRegistry>(1)
                   .registry<xyco::io::IoRegistry>(4)
                   .registry<xyco::time::TimeRegistry>()
-                  .on_worker_start([]() {})
-                  .on_worker_stop([]() {})
                   .build();
 }


### PR DESCRIPTION
- Runtime decoupling: `Driver` independent of `Runtime`, less friendship between `Runtime`, `Worker` and `Builder`.
- Deprecate unused runtime hooks in start & end phase.
- Uncaught coroutine exception: crash worker(thread) -> crash process.