### PR TITLE
[Chore] split epoll and uring linting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,4 +7,4 @@
 #
 # To enable this hook, rename this file to "pre-commit".
 
-find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics -i --verbose
+find . -type f \( -name \*.cc -or -name \*.h -or -name \*.ccm \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics -i --verbose

--- a/.githooks/pre-rebase
+++ b/.githooks/pre-rebase
@@ -15,4 +15,4 @@
 # merged to 'next' branch from getting rebased, because allowing it
 # would result in rebasing already published history.
 
-find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics -i --verbose
+find . -type f \( -name \*.cc -or -name \*.h -or -name \*.ccm \) -not -path ./build/\* | xargs clang-format --Werror --fcolor-diagnostics -i --verbose

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -10,7 +10,21 @@ env:
   llvm_version: 17
 
 jobs:
-  cpp-build:
+  cpp-check-epoll:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: install essential packages
+        run: |
+          sudo apt-get install -y libboost-all-dev
+          sudo bash scripts/install_build_toolchain.sh $llvm_version
+      - name: build
+        run: |
+          find . -type f \( -name \*.cc -or -name \*.h -or -name \*.ccm \) | xargs clang-format-$llvm_version --Werror --fcolor-diagnostics --dry-run --verbose
+          LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset epoll_ci_linting_logging_off
+          LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset epoll_ci_linting_logging_on
+
+  cpp-check-uring:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -20,11 +34,11 @@ jobs:
           sudo bash scripts/install_build_toolchain.sh $llvm_version
       - name: build
         run: |
-          find . -type f \( -name \*.cc -or -name \*.h \) -not -path ./build/\* | xargs clang-format-$llvm_version --Werror --fcolor-diagnostics --dry-run --verbose
-          LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset ci_linting_with_logging_off
-          LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset ci_linting_with_logging_on
+          find . -type f \( -name \*.cc -or -name \*.h -or -name \*.ccm \) | xargs clang-format-$llvm_version --Werror --fcolor-diagnostics --dry-run --verbose
+          LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset uring_ci_linting_logging_off
+          LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset uring_ci_linting_logging_on
 
-  cpp-test:
+  unit-test:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif()
 
 # External dependencies ought to be declared ahead to skip linting for them
-if(ENABLE_LINTING)
+if(XYCO_ENABLE_LINTING)
   add_compile_options(-Wall -Wextra -Wdeprecated -Werror)
   set(CMAKE_CXX_CLANG_TIDY
       clang-tidy-$ENV{LLVM_VERSION}
@@ -55,7 +55,7 @@ if(ENABLE_LINTING)
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/overload.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/panic.dir/
   )
-endif(ENABLE_LINTING)
+endif(XYCO_ENABLE_LINTING)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   add_subdirectory(tests)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,9 @@
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-                "CMAKE_CXX_COMPILER": "clang-$env{LLVM_VERSION}"
+                "CMAKE_CXX_COMPILER": "clang-$env{LLVM_VERSION}",
+                "XYCO_ENABLE_LOGGING": "$env{XYCO_ENABLE_LOGGING}",
+                "XYCO_ENABLE_LINTING": "$env{XYCO_ENABLE_LINTING}"
             }
         },
         {
@@ -22,62 +24,62 @@
             "inherits": [
                 "root"
             ],
-            "cacheVariables": {
-                "XYCO_ENABLE_LOGGING": "ON"
+            "environment": {
+                "XYCO_ENABLE_LOGGING": "true"
             }
         },
         {
-            "name": "disable_logging",
-            "displayName": "Disable Logging Config",
+            "name": "enable_linting",
+            "displayName": "Enable Linting Config",
             "inherits": [
                 "root"
             ],
-            "cacheVariables": {
-                "XYCO_ENABLE_LOGGING": "OFF"
+            "environment": {
+                "XYCO_ENABLE_LINTING": "true"
             }
         },
         {
-            "name": "ci_linting_with_logging_off",
+            "name": "ci_linting_logging_off",
             "displayName": "CI Linting with Logging Off Config",
             "inherits": [
-                "root"
-            ],
-            "cacheVariables": {
-                "XYCO_ENABLE_LOGGING": "OFF",
-                "ENABLE_LINTING": true
-            }
+                "enable_linting"
+            ]
         },
         {
-            "name": "ci_linting_with_logging_on",
+            "name": "ci_linting_logging_on",
             "displayName": "CI Linting with Logging On Config",
             "inherits": [
-                "root"
-            ],
-            "cacheVariables": {
-                "XYCO_ENABLE_LOGGING": "ON",
-                "ENABLE_LINTING": true
-            }
+                "enable_linting",
+                "enable_logging"
+            ]
         }
     ],
     "buildPresets": [
         {
-            "name": "root",
+            "name": "release_mode",
             "hidden": true,
             "configuration": "Release"
         },
         {
-            "name": "all_targets",
+            "name": "epoll_targets",
             "hidden": true,
             "targets": [
                 "xyco_epoll_echo_server",
                 "xyco_epoll_http_server",
                 "xyco_epoll_main",
+                "xyco_test_epoll",
+                "asio_echo_server"
+            ]
+        },
+        {
+            "name": "uring_targets",
+            "hidden": true,
+            "targets": [
                 "xyco_uring_echo_server",
                 "xyco_uring_http_server",
                 "xyco_uring_main",
-                "asio_echo_server",
-                "xyco_test_epoll",
-                "xyco_test_uring"
+                "xyco_test_uring",
+                "asio_echo_server"
             ]
         },
         {
@@ -89,56 +91,105 @@
             ]
         },
         {
-            "name": "ci_linting_with_logging_off",
+            "name": "epoll_ci_linting_logging_off",
+            "displayName": "CI Linting Build of Epoll targets with Logging Off",
             "inherits": [
-                "root",
-                "all_targets"
+                "release_mode",
+                "epoll_targets"
             ],
-            "configurePreset": "ci_linting_with_logging_off"
+            "configurePreset": "ci_linting_logging_off"
         },
         {
-            "name": "ci_linting_with_logging_on",
+            "name": "epoll_ci_linting_logging_on",
+            "displayName": "CI Linting Build of Epoll targets with Logging On",
             "inherits": [
-                "root",
-                "all_targets"
+                "release_mode",
+                "epoll_targets"
             ],
-            "configurePreset": "ci_linting_with_logging_on"
+            "configurePreset": "ci_linting_logging_on"
         },
         {
-            "name": "test",
+            "name": "uring_ci_linting_logging_off",
+            "displayName": "CI Linting Build of Uring targets with Logging Off",
+            "inherits": [
+                "release_mode",
+                "uring_targets"
+            ],
+            "configurePreset": "ci_linting_logging_off"
+        },
+        {
+            "name": "uring_ci_linting_logging_on",
+            "displayName": "CI Linting Build of Uring targets with Logging On",
+            "inherits": [
+                "release_mode",
+                "uring_targets"
+            ],
+            "configurePreset": "ci_linting_logging_on"
+        },
+        {
+            "name": "ci_test",
+            "displayName": "CI Test Build",
             "configurePreset": "enable_logging",
             "inherits": [
-                "root",
+                "release_mode",
                 "test_targets"
             ]
         }
     ],
     "workflowPresets": [
         {
-            "name": "ci_linting_with_logging_off",
-            "displayName": "CI Linting with Logging Off Workflow",
+            "name": "epoll_ci_linting_logging_off",
+            "displayName": "CI Linting Workflow of Epoll targets with Logging Off",
             "steps": [
                 {
                     "type": "configure",
-                    "name": "ci_linting_with_logging_off"
+                    "name": "ci_linting_logging_off"
                 },
                 {
                     "type": "build",
-                    "name": "ci_linting_with_logging_off"
+                    "name": "epoll_ci_linting_logging_off"
                 }
             ]
         },
         {
-            "name": "ci_linting_with_logging_on",
-            "displayName": "CI Linting with Logging On Workflow",
+            "name": "uring_ci_linting_logging_off",
+            "displayName": "CI Linting Workflow of Uring targets with Logging Off",
             "steps": [
                 {
                     "type": "configure",
-                    "name": "ci_linting_with_logging_on"
+                    "name": "ci_linting_logging_off"
                 },
                 {
                     "type": "build",
-                    "name": "ci_linting_with_logging_on"
+                    "name": "uring_ci_linting_logging_off"
+                }
+            ]
+        },
+        {
+            "name": "epoll_ci_linting_logging_on",
+            "displayName": "CI Linting Workflow of Epoll targets with Logging On",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "ci_linting_logging_on"
+                },
+                {
+                    "type": "build",
+                    "name": "epoll_ci_linting_logging_on"
+                }
+            ]
+        },
+        {
+            "name": "uring_ci_linting_logging_on",
+            "displayName": "CI Linting Workflow of Uring targets with Logging On",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "ci_linting_logging_on"
+                },
+                {
+                    "type": "build",
+                    "name": "uring_ci_linting_logging_on"
                 }
             ]
         },
@@ -152,7 +203,7 @@
                 },
                 {
                     "type": "build",
-                    "name": "test"
+                    "name": "ci_test"
                 }
             ]
         }

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,11 +11,11 @@ target_include_directories(
   asio_echo_server PUBLIC ${CMAKE_BINARY_DIR}/_deps/asio-src/asio/include)
 target_link_libraries(asio_echo_server GSL)
 
-if(ENABLE_LINTING)
+if(XYCO_ENABLE_LINTING)
   target_compile_options(
     asio_echo_server
     PRIVATE -Wno-deprecated-copy-with-user-provided-dtor
             -Wno-deprecated-literal-operator
             -Wno-deprecated-redundant-constexpr-static-def
             -Wno-unknown-pragmas)
-endif(ENABLE_LINTING)
+endif(XYCO_ENABLE_LINTING)

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ flag_management:
       paths:
         - "include/"
         - "!include/xyco/fs/io_uring/"
-        - "!include/xyoc/io/io_uring/"
+        - "!include/xyco/io/io_uring/"
         - "!include/xyco/net/io_uring/"
         - "src/"
         - "!src/fs/io_uring/"
@@ -20,7 +20,7 @@ flag_management:
       paths:
         - "include/"
         - "!include/xyco/fs/epoll/"
-        - "!include/xyoc/io/epoll/"
+        - "!include/xyco/io/epoll/"
         - "!include/xyco/net/epoll/"
         - "src/"
         - "!src/fs/epoll/"


### PR DESCRIPTION
This is a prerequisite for a pure module implementation of io, net , fs parts. Prebuilt module paths needs to be explicitly listed for CMake integrated clang tidy, so epoll and uring modules with the same name cannot be distinguished by tidy.