### PR TITLE
[Build] use nix flake to build unit test binary

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,5 +7,5 @@ runs:
       run: |
         sudo apt-get install -y lcov libboost-all-dev liburing-dev
         sudo bash scripts/install_build_toolchain.sh $llvm_version
-        ln -s $(which lld-$llvm_version) /usr/bin/lld
-        ln -s $(which clang++-$llvm_version) /usr/bin/clang++
+        ln -s $(which lld-$llvm_version) /usr/local/bin/lld
+        ln -s $(which clang++-$llvm_version) /usr/local/bin/clang++

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,3 +7,5 @@ runs:
       run: |
         sudo apt-get install -y lcov libboost-all-dev liburing-dev
         sudo bash scripts/install_build_toolchain.sh $llvm_version
+        ln -s $(which lld-$llvm_version) /usr/bin/lld
+        ln -s $(which clang++-$llvm_version) /usr/bin/clang++

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -6,12 +6,12 @@ runs:
       shell: bash
       run: |
         nix build .#unittest
-        LLVM_PROFILE_FILE="result/xyco_test_epoll.profraw" SPDLOG_LEVEL=info result/xyco_test_epoll --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
-        llvm-profdata-$llvm_version merge -sparse result/xyco_test_epoll.profraw -o result/xyco_test_epoll.profdata
-        llvm-cov-$llvm_version show result/xyco_test_epoll -ignore-filename-regex=build -instr-profile=result/xyco_test_epoll.profdata > coverage_epoll.txt
-        LLVM_PROFILE_FILE="result/xyco_test_uring.profraw" SPDLOG_LEVEL=info result/xyco_test_uring --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
-        llvm-profdata-$llvm_version merge -sparse result/xyco_test_uring.profraw -o result/xyco_test_uring.profdata
-        llvm-cov-$llvm_version show result/xyco_test_uring -ignore-filename-regex=build -instr-profile=result/xyco_test_uring.profdata > coverage_uring.txt
+        LLVM_PROFILE_FILE="xyco_test_epoll.profraw" SPDLOG_LEVEL=info result/xyco_test_epoll --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+        llvm-profdata-$llvm_version merge -sparse xyco_test_epoll.profraw -o xyco_test_epoll.profdata
+        llvm-cov-$llvm_version show result/xyco_test_epoll -ignore-filename-regex=build -instr-profile=xyco_test_epoll.profdata > coverage_epoll.txt
+        LLVM_PROFILE_FILE="xyco_test_uring.profraw" SPDLOG_LEVEL=info result/xyco_test_uring --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+        llvm-profdata-$llvm_version merge -sparse xyco_test_uring.profraw -o xyco_test_uring.profdata
+        llvm-cov-$llvm_version show result/xyco_test_uring -ignore-filename-regex=build -instr-profile=xyco_test_uring.profdata > coverage_uring.txt
     - name: upload epoll coverage report
       uses: codecov/codecov-action@v3
       with:

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -5,14 +5,13 @@ runs:
     - name: run unit test
       shell: bash
       run: |
-        BINARY_DIR=build/enable_logging/tests
-        LLVM_VERSION=$llvm_version /usr/bin/cmake --workflow --preset ci_test
-        LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_epoll.profraw" SPDLOG_LEVEL=info $BINARY_DIR/xyco_test_epoll --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
-        llvm-profdata-$llvm_version merge -sparse $BINARY_DIR/xyco_test_epoll.profraw -o $BINARY_DIR/xyco_test_epoll.profdata
-        llvm-cov-$llvm_version show $BINARY_DIR/xyco_test_epoll -ignore-filename-regex=build -instr-profile=$BINARY_DIR/xyco_test_epoll.profdata > coverage_epoll.txt
-        LLVM_PROFILE_FILE="$BINARY_DIR/xyco_test_uring.profraw" SPDLOG_LEVEL=info $BINARY_DIR/xyco_test_uring --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
-        llvm-profdata-$llvm_version merge -sparse $BINARY_DIR/xyco_test_uring.profraw -o $BINARY_DIR/xyco_test_uring.profdata
-        llvm-cov-$llvm_version show $BINARY_DIR/xyco_test_uring -ignore-filename-regex=build -instr-profile=$BINARY_DIR/xyco_test_uring.profdata > coverage_uring.txt
+        nix build .#unittest
+        LLVM_PROFILE_FILE="result/xyco_test_epoll.profraw" SPDLOG_LEVEL=info result/xyco_test_epoll --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+        llvm-profdata-$llvm_version merge -sparse result/xyco_test_epoll.profraw -o result/xyco_test_epoll.profdata
+        llvm-cov-$llvm_version show result/xyco_test_epoll -ignore-filename-regex=build -instr-profile=result/xyco_test_epoll.profdata > coverage_epoll.txt
+        LLVM_PROFILE_FILE="result/xyco_test_uring.profraw" SPDLOG_LEVEL=info result/xyco_test_uring --gtest_repeat=1 --gtest_break_on_failure --gtest_shuffle --gtest_death_test_style=threadsafe
+        llvm-profdata-$llvm_version merge -sparse result/xyco_test_uring.profraw -o result/xyco_test_uring.profdata
+        llvm-cov-$llvm_version show result/xyco_test_uring -ignore-filename-regex=build -instr-profile=result/xyco_test_uring.profdata > coverage_uring.txt
     - name: upload epoll coverage report
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -37,4 +37,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: ./.github/actions/unit_test

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: ./.github/actions/unit_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(
 set(CMAKE_CXX_STANDARD 23)
 
 add_compile_options(-std=c++2b -stdlib=libc++)
-add_link_options(-fuse-ld=lld-$ENV{LLVM_VERSION} -lc++ -lm -rdynamic)
+add_link_options(-fuse-ld=lld -lc++ -lm -rdynamic)
 cmake_policy(SET CMP0135 NEW)
 
 include(FetchContent)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,7 @@
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-                "CMAKE_CXX_COMPILER": "clang-$env{LLVM_VERSION}",
+                "CMAKE_CXX_COMPILER": "clang++",
                 "XYCO_ENABLE_LOGGING": "$env{XYCO_ENABLE_LOGGING}",
                 "XYCO_ENABLE_LINTING": "$env{XYCO_ENABLE_LINTING}"
             }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1680978846,
+        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "xyos";
+
+  inputs = {
+    systems.url = "github:nix-systems/x86_64-linux";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.unittest = pkgs.callPackage ./package.nix { };
+      });
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,74 @@
+{ lib, pkgs, fetchurl, llvmPackages }:
+
+# stdenv.mkDerivation now accepts a list of named parameters that describe
+# the package itself.
+
+llvmPackages.libcxxStdenv.mkDerivation rec {
+  name = "xyco";
+
+  # good source filtering is important for caching of builds.
+  # It's easier when subprojects have their own distinct subfolders.
+  src = lib.sourceByRegex ./. [
+    "^benchmark.*"
+    "^examples.*"
+    "^include.*"
+    "^src.*"
+    "^tests.*"
+    "CMakeLists.txt"
+    "CMakePresets.json"
+  ];
+
+  depAsio = fetchurl
+    {
+      name = "asio";
+      url = "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-0.tar.gz";
+      sha256 = "ImQ4sHmAma0qICVjqDVxzgbdE7Vw2P3tSEDbwfl/oyg=";
+    };
+  depGoogletest = fetchurl
+    {
+      name = "googletest";
+      url = "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz";
+      sha256 = "gZZP5XjpvXyU39sJyOTW5nWeGZZ+OX2+pI0cEORdDfI=";
+    };
+  depGSL = fetchurl
+    {
+      name = "GSL";
+      url = "https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.tar.gz";
+      sha256 = "8OMssQZU/qka1WveiRcNeM+/Q2PuCwHY8JfeK6SfbOk=";
+    };
+  depSpdlog = fetchurl
+    {
+      name = "spdlog";
+      url = "https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz";
+      sha256 = "Tczy0Q9BDB4v6v+Jlmv8SaGrsp728IJGM1sRDgAeCak=";
+    };
+
+  HTTP_PROXY = "http://127.0.0.1:7890";
+  HTTPS_PROXY = "http://127.0.0.1:7890";
+
+  # We now list the dependencies similar to the devShell before.
+  # Distinguishing between `nativeBuildInputs` (runnable on the host
+  # at compile time) and normal `buildInputs` (runnable on target
+  # platform at run time) is an important preparation for cross-compilation.
+  nativeBuildInputs = with pkgs; [ autoPatchelfHook cmake ninja llvmPackages.clang-tools llvmPackages.lld ];
+  buildInputs = with pkgs; [ boost liburing ];
+
+  configurePhase = ''
+    DEP_DIR_PATTERN="build/enable_logging/_deps/{}-subbuild/{}-populate-prefix/src"
+    ASIO_DIR=$(echo $DEP_DIR_PATTERN | sed -e "s/{}/asio/g")
+    GOOGLETEST_DIR=$(echo $DEP_DIR_PATTERN | sed -e "s/{}/googletest/g")
+    GSL_DIR=$(echo $DEP_DIR_PATTERN | sed -e "s/{}/gsl/g")
+    SPDLOG_DIR=$(echo $DEP_DIR_PATTERN | sed -e "s/{}/spdlog/g")
+    mkdir -p $ASIO_DIR $GOOGLETEST_DIR $GSL_DIR $SPDLOG_DIR
+    cp -r ${depAsio} $ASIO_DIR/asio-1-28-0.tar.gz
+    cp -r ${depGoogletest} $GOOGLETEST_DIR/release-1.12.1.tar.gz
+    cp -r ${depGSL} $GSL_DIR/v4.0.0.tar.gz
+    cp -r ${depSpdlog} $SPDLOG_DIR/v1.12.0.tar.gz
+    cmake --preset enable_logging
+  '';
+  buildPhase = ''cmake --build --preset ci_test'';
+  installPhase = ''
+    mkdir $out
+    cp build/enable_logging/tests/xyco_test_* $out/
+  '';
+}


### PR DESCRIPTION
Nix provides reproducibility as a purely functional package manager. So we will gradually switch to Nix for all packaging and toolchain management of the project. This PR provides a Nix package setup and migrate unit test binary first due to less dependency on toolchain.