### PR TITLE
[Build] migrate from CMake FetchContent dependencies to nixpkgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,36 +13,7 @@ add_compile_options(-fstack-protector-all -fwrapv)
 add_link_options(-fuse-ld=lld -rdynamic -stdlib=libc++)
 cmake_policy(SET CMP0135 NEW)
 
-include(FetchContent)
-FetchContent_Declare(
-  GSL
-  URL "https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.tar.gz"
-  URL_HASH
-    SHA256=f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9)
-FetchContent_MakeAvailable(GSL)
-
-set(SPDLOG_USE_STD_FORMAT ON)
-FetchContent_Declare(
-  spdlog
-  URL "https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"
-  URL_HASH
-    SHA256=4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9)
-FetchContent_MakeAvailable(spdlog)
-
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  FetchContent_Declare(
-    googletest
-    URL "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz"
-    URL_HASH
-      SHA256=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2)
-  FetchContent_MakeAvailable(googletest)
-  FetchContent_Declare(
-    asio
-    URL "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-0.tar.gz"
-    URL_HASH
-      SHA256=226438b0798099ad2a202563a83571ce06dd13b570d8fded4840dbc1f97fa328)
-  FetchContent_MakeAvailable(asio)
-endif()
+add_compile_definitions(SPDLOG_USE_STD_FORMAT ON)
 
 # External dependencies ought to be declared ahead to skip linting for them
 if(XYCO_ENABLE_LINTING)
@@ -107,8 +78,7 @@ add_library(xyco_future src/runtime/future.cc)
 add_library(xyco::future ALIAS xyco_future)
 target_sources(xyco_future PUBLIC FILE_SET future_module TYPE CXX_MODULES FILES
                                   include/xyco/runtime/future.ccm)
-target_link_libraries(xyco_future PUBLIC GSL
-                                         ${Boost_STACKTRACE_ADDR2LINE_LIBRARY})
+target_link_libraries(xyco_future PUBLIC ${Boost_STACKTRACE_ADDR2LINE_LIBRARY})
 
 add_library(xyco_panic src/utils/panic.cc)
 add_library(xyco::panic ALIAS xyco_panic)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -9,9 +9,8 @@ target_link_libraries(
                                  xyco::runtime)
 
 add_executable(asio_echo_server asio_echo_server.cc)
-target_include_directories(
-  asio_echo_server PUBLIC ${CMAKE_BINARY_DIR}/_deps/asio-src/asio/include)
-target_link_libraries(asio_echo_server GSL)
+target_compile_definitions(asio_echo_server PUBLIC ASIO_HAS_CO_AWAIT=1
+                                                   ASIO_HAS_STD_COROUTINE=1)
 
 if(XYCO_ENABLE_LINTING)
   target_compile_options(

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,40 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+        llvmPackages = pkgs.llvmPackages_18;
+        microsoft-gsl = pkgs.microsoft-gsl;
+        asio = pkgs.asio;
+        spdlog = pkgs.spdlog.overrideAttrs {
+          cmakeFlags = [ "-DSPDLOG_USE_STD_FORMAT=ON" ];
+        };
+        gtest = pkgs.gtest.override {
+          stdenv = llvmPackages.libcxxStdenv;
+          static = true;
+        };
       in
       {
-        packages.unit-test = pkgs.callPackage ./unit-test.nix { llvmPackages = pkgs.llvmPackages_18; };
-        packages.lint-epoll = pkgs.callPackage ./lint.nix { llvmPackages = pkgs.llvmPackages_18; IOAPI = "epoll"; };
-        packages.lint-uring = pkgs.callPackage ./lint.nix { llvmPackages = pkgs.llvmPackages_18; IOAPI = "uring"; };
+        packages.unit-test = pkgs.callPackage ./unit-test.nix {
+          llvmPackages = llvmPackages;
+          asio = asio;
+          gtest = gtest;
+          microsoft-gsl = microsoft-gsl;
+          spdlog = spdlog;
+        };
+        packages.lint-epoll = pkgs.callPackage ./lint.nix {
+          llvmPackages = llvmPackages;
+          asio = asio;
+          gtest = gtest;
+          microsoft-gsl = microsoft-gsl;
+          spdlog = spdlog;
+          IOAPI = "epoll";
+        };
+        packages.lint-uring = pkgs.callPackage ./lint.nix {
+          llvmPackages = llvmPackages;
+          asio = asio;
+          gtest = gtest;
+          microsoft-gsl = microsoft-gsl;
+          spdlog = spdlog;
+          IOAPI = "uring";
+        };
       });
 }

--- a/lint.nix
+++ b/lint.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, fetchurl, llvmPackages, IOAPI }:
+{ lib, pkgs, llvmPackages, asio, gtest, microsoft-gsl, spdlog, IOAPI }:
 
-llvmPackages.libcxxStdenv.mkDerivation rec {
+llvmPackages.libcxxStdenv.mkDerivation {
   name = "xyco";
 
   src = lib.sourceByRegex ./. [
@@ -15,59 +15,25 @@ llvmPackages.libcxxStdenv.mkDerivation rec {
     ".clang-tidy"
   ];
 
-  depAsio = fetchurl
-    {
-      name = "asio";
-      url = "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-0.tar.gz";
-      sha256 = "ImQ4sHmAma0qICVjqDVxzgbdE7Vw2P3tSEDbwfl/oyg=";
-    };
-  depGoogletest = fetchurl
-    {
-      name = "googletest";
-      url = "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz";
-      sha256 = "gZZP5XjpvXyU39sJyOTW5nWeGZZ+OX2+pI0cEORdDfI=";
-    };
-  depGSL = fetchurl
-    {
-      name = "GSL";
-      url = "https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.tar.gz";
-      sha256 = "8OMssQZU/qka1WveiRcNeM+/Q2PuCwHY8JfeK6SfbOk=";
-    };
-  depSpdlog = fetchurl
-    {
-      name = "spdlog";
-      url = "https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz";
-      sha256 = "Tczy0Q9BDB4v6v+Jlmv8SaGrsp728IJGM1sRDgAeCak=";
-    };
-
-  nativeBuildInputs = with pkgs; [ autoPatchelfHook cmake ninja (llvmPackages.clang-tools.override { enableLibcxx = true; }) llvmPackages.lld ];
-  buildInputs = with pkgs; [ boost liburing ];
+  nativeBuildInputs = with pkgs; [
+    autoPatchelfHook
+    cmake
+    ninja
+    (llvmPackages.clang-tools.override { enableLibcxx = true; })
+    llvmPackages.lld
+  ];
+  buildInputs = [
+    pkgs.boost
+    pkgs.liburing
+    microsoft-gsl
+    asio
+    spdlog
+    gtest
+  ];
 
   configurePhase = ''
     runHook preConfigure
 
-    LOGGING_OFF_DEP_DIR_PATTERN="build/ci_linting_logging_off/_deps/{}-subbuild/{}-populate-prefix/src"
-    ASIO_DIR=$(echo $LOGGING_OFF_DEP_DIR_PATTERN | sed -e "s/{}/asio/g")
-    GOOGLETEST_DIR=$(echo $LOGGING_OFF_DEP_DIR_PATTERN | sed -e "s/{}/googletest/g")
-    GSL_DIR=$(echo $LOGGING_OFF_DEP_DIR_PATTERN | sed -e "s/{}/gsl/g")
-    SPDLOG_DIR=$(echo $LOGGING_OFF_DEP_DIR_PATTERN | sed -e "s/{}/spdlog/g")
-    mkdir -p $ASIO_DIR $GOOGLETEST_DIR $GSL_DIR $SPDLOG_DIR
-    cp -r ${depAsio} $ASIO_DIR/asio-1-28-0.tar.gz
-    cp -r ${depGoogletest} $GOOGLETEST_DIR/release-1.12.1.tar.gz
-    cp -r ${depGSL} $GSL_DIR/v4.0.0.tar.gz
-    cp -r ${depSpdlog} $SPDLOG_DIR/v1.12.0.tar.gz
-
-    LOGGING_ON_DEP_DIR_PATTERN="build/ci_linting_logging_on/_deps/{}-subbuild/{}-populate-prefix/src"
-    ASIO_DIR=$(echo $LOGGING_ON_DEP_DIR_PATTERN | sed -e "s/{}/asio/g")
-    GOOGLETEST_DIR=$(echo $LOGGING_ON_DEP_DIR_PATTERN | sed -e "s/{}/googletest/g")
-    GSL_DIR=$(echo $LOGGING_ON_DEP_DIR_PATTERN | sed -e "s/{}/gsl/g")
-    SPDLOG_DIR=$(echo $LOGGING_ON_DEP_DIR_PATTERN | sed -e "s/{}/spdlog/g")
-    mkdir -p $ASIO_DIR $GOOGLETEST_DIR $GSL_DIR $SPDLOG_DIR
-    cp -r ${depAsio} $ASIO_DIR/asio-1-28-0.tar.gz
-    cp -r ${depGoogletest} $GOOGLETEST_DIR/release-1.12.1.tar.gz
-    cp -r ${depGSL} $GSL_DIR/v4.0.0.tar.gz
-    cp -r ${depSpdlog} $SPDLOG_DIR/v1.12.0.tar.gz
-    
     cmake --preset ci_linting_logging_off
     cmake --preset ci_linting_logging_on
 


### PR DESCRIPTION
- Let nix manage all external dependencies so we can bypass the restriction that internet is unavailable in build phase.
- Upgrade external dependencies to the nixpkgs version to avoid complex src override.