### PR TITLE
[Build] unify io related targets

### DIFF
--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -7,13 +7,17 @@ runs:
   steps:
     - name: run unit test
       shell: bash
-      run: nix build --print-build-logs .#unit-test
+      run: |
+        nix build --print-build-logs .#unit-test-epoll
+        cp result/coverage_epoll.txt coverage_epoll.txt
+        nix build --print-build-logs .#unit-test-uring
+        cp result/coverage_io_uring.txt coverage_io_uring.txt
     - name: upload epoll coverage report
       uses: codecov/codecov-action@v3
       with:
         token: ${{ inputs.codecov_token }}
         flags: epoll
-        files: result/coverage_epoll.txt
+        files: coverage_epoll.txt
         fail_ci_if_error: true
         verbose: true
     - name: upload uring coverage report
@@ -21,7 +25,7 @@ runs:
       with:
         token: ${{ inputs.codecov_token }}
         flags: uring
-        files: result/coverage_uring.txt
+        files: coverage_io_uring.txt
         fail_ci_if_error: true
         verbose: true
     - name: upload tests coverage report
@@ -29,6 +33,6 @@ runs:
       with:
         token: ${{ inputs.codecov_token }}
         flags: tests
-        files: result/coverage_epoll.txt,result/coverage_uring.txt
+        files: coverage_epoll.txt,coverage_io_uring.txt
         fail_ci_if_error: true
         verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,20 +34,14 @@ if(XYCO_ENABLE_LINTING)
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_task.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_time.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_sync.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_io_all.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_io_epoll.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_io_uring.dir/
+      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_io.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_io_common.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_net_all.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_net_epoll.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_net_uring.dir/
+      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_net.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_net_common.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_fs_all.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_fs_epoll.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_fs_uring.dir/
+      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_fs.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_fs_common.dir/
       --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/CMakeFiles/xyco_libc.dir/
-      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/tests/CMakeFiles/xyco_test_common_utils.dir/
+      --extra-arg=-fprebuilt-module-path=${CMAKE_BINARY_DIR}/tests/CMakeFiles/xyco_test_utils.dir/
   )
 endif(XYCO_ENABLE_LINTING)
 
@@ -59,13 +53,8 @@ endif()
 
 find_package(Boost REQUIRED)
 
-add_executable(xyco_epoll_main src/main.cc)
-target_link_libraries(xyco_epoll_main xyco::io_epoll xyco::net_epoll
-                      xyco::runtime)
-
-add_executable(xyco_uring_main src/main.cc)
-target_link_libraries(xyco_uring_main xyco::io_uring xyco::net_uring
-                      xyco::runtime)
+add_executable(xyco_main src/main.cc)
+target_link_libraries(xyco_main xyco::io xyco::net xyco::runtime)
 
 # Reusable library
 
@@ -194,52 +183,39 @@ target_link_libraries(
   xyco_io_common
   PUBLIC xyco::future
   PRIVATE xyco::runtime_ctx xyco::libc)
-add_library(xyco_io_epoll src/io/epoll/registry.cc)
-add_library(xyco::io_epoll ALIAS xyco_io_epoll)
-target_sources(
-  xyco_io_epoll
-  PUBLIC FILE_SET
-         io_epoll_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/io/epoll/mod.ccm
-         include/xyco/io/epoll/registry.ccm)
-target_link_libraries(
-  xyco_io_epoll
-  PUBLIC xyco_io_common
-  PRIVATE xyco::runtime_ctx xyco::libc)
-add_library(xyco_io_uring src/io/io_uring/registry.cc)
-add_library(xyco::io_uring ALIAS xyco_io_uring)
-target_sources(
-  xyco_io_uring
-  PUBLIC FILE_SET
-         io_uring_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/io/io_uring/mod.ccm
-         include/xyco/io/io_uring/registry.ccm)
-target_link_libraries(
-  xyco_io_uring
-  PUBLIC xyco_io_common
-  PRIVATE xyco::runtime_ctx uring xyco::libc)
-add_library(xyco_io_all src/io/epoll/registry.cc src/io/io_uring/registry.cc)
-add_library(xyco::io_all ALIAS xyco_io_all)
-target_sources(
-  xyco_io_all
-  PUBLIC FILE_SET
-         io_all_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/io/mod.ccm
-         include/xyco/io/epoll/registry.ccm
-         include/xyco/io/io_uring/registry.ccm)
-target_link_libraries(
-  xyco_io_all
-  PUBLIC xyco_io_common
-  PRIVATE xyco::runtime_ctx uring xyco::libc)
+if(XYCO_IO_API STREQUAL "epoll")
+  add_library(xyco_io src/io/epoll/registry.cc)
+  add_library(xyco::io ALIAS xyco_io)
+  target_sources(
+    xyco_io
+    PUBLIC FILE_SET
+           io_module
+           TYPE
+           CXX_MODULES
+           FILES
+           include/xyco/io/epoll/mod.ccm
+           include/xyco/io/epoll/registry.ccm)
+  target_link_libraries(
+    xyco_io
+    PUBLIC xyco_io_common
+    PRIVATE xyco::runtime_ctx xyco::libc)
+elseif(XYCO_IO_API STREQUAL "io_uring")
+  add_library(xyco_io src/io/io_uring/registry.cc)
+  add_library(xyco::io ALIAS xyco_io)
+  target_sources(
+    xyco_io
+    PUBLIC FILE_SET
+           io_module
+           TYPE
+           CXX_MODULES
+           FILES
+           include/xyco/io/io_uring/mod.ccm
+           include/xyco/io/io_uring/registry.ccm)
+  target_link_libraries(
+    xyco_io
+    PUBLIC xyco_io_common
+    PRIVATE xyco::runtime_ctx uring xyco::libc)
+endif()
 
 add_library(xyco_net_common src/net/socket.cc)
 target_sources(
@@ -255,52 +231,39 @@ target_link_libraries(
   xyco_net_common
   INTERFACE xyco::future
   PRIVATE xyco::runtime_ctx xyco::libc)
-add_library(xyco_net_epoll src/net/epoll/listener.cc)
-add_library(xyco::net_epoll ALIAS xyco_net_epoll)
-target_sources(
-  xyco_net_epoll
-  PUBLIC FILE_SET
-         net_epoll_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/net/epoll/mod.ccm
-         include/xyco/net/epoll/listener.ccm)
-target_link_libraries(
-  xyco_net_epoll
-  PUBLIC xyco_net_common
-  PRIVATE xyco::io_epoll xyco::task xyco::runtime_ctx xyco::libc)
-add_library(xyco_net_uring src/net/io_uring/listener.cc)
-add_library(xyco::net_uring ALIAS xyco_net_uring)
-target_sources(
-  xyco_net_uring
-  PUBLIC FILE_SET
-         net_uring_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/net/io_uring/mod.ccm
-         include/xyco/net/io_uring/listener.ccm)
-target_link_libraries(
-  xyco_net_uring
-  PUBLIC xyco_net_common
-  PRIVATE xyco::io_uring xyco::task xyco::runtime_ctx xyco::libc)
-add_library(xyco_net_all src/net/epoll/listener.cc src/net/io_uring/listener.cc)
-add_library(xyco::net_all ALIAS xyco_net_all)
-target_sources(
-  xyco_net_all
-  PUBLIC FILE_SET
-         net_all_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/net/mod.ccm
-         include/xyco/net/epoll/listener.ccm
-         include/xyco/net/io_uring/listener.ccm)
-target_link_libraries(
-  xyco_net_all
-  PUBLIC xyco_net_common
-  PRIVATE xyco::io_all xyco::task xyco::runtime_ctx xyco::libc)
+if(XYCO_IO_API STREQUAL "epoll")
+  add_library(xyco_net src/net/epoll/listener.cc)
+  add_library(xyco::net ALIAS xyco_net)
+  target_sources(
+    xyco_net
+    PUBLIC FILE_SET
+           net_module
+           TYPE
+           CXX_MODULES
+           FILES
+           include/xyco/net/epoll/mod.ccm
+           include/xyco/net/epoll/listener.ccm)
+  target_link_libraries(
+    xyco_net
+    PUBLIC xyco_net_common
+    PRIVATE xyco::io xyco::task xyco::runtime_ctx xyco::libc)
+elseif(XYCO_IO_API STREQUAL "io_uring")
+  add_library(xyco_net src/net/io_uring/listener.cc)
+  add_library(xyco::net ALIAS xyco_net)
+  target_sources(
+    xyco_net
+    PUBLIC FILE_SET
+           net_module
+           TYPE
+           CXX_MODULES
+           FILES
+           include/xyco/net/io_uring/mod.ccm
+           include/xyco/net/io_uring/listener.ccm)
+  target_link_libraries(
+    xyco_net
+    PUBLIC xyco_net_common
+    PRIVATE xyco::io xyco::task xyco::runtime_ctx xyco::libc)
+endif()
 
 add_library(xyco_fs_common src/fs/utils.cc)
 target_sources(
@@ -317,52 +280,39 @@ target_link_libraries(
   xyco_fs_common
   PUBLIC xyco::future
   PRIVATE xyco::task xyco::runtime_ctx xyco::libc)
-add_library(xyco_fs_epoll src/fs/epoll/file.cc)
-add_library(xyco::fs_epoll ALIAS xyco_fs_epoll)
-target_sources(
-  xyco_fs_epoll
-  PUBLIC FILE_SET
-         fs_epoll_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/fs/epoll/mod.ccm
-         include/xyco/fs/epoll/file.ccm)
-target_link_libraries(
-  xyco_fs_epoll
-  PUBLIC xyco_fs_common
-  PRIVATE xyco::io_epoll xyco::task xyco::runtime_ctx xyco::libc)
-add_library(xyco_fs_uring src/fs/io_uring/file.cc)
-add_library(xyco::fs_uring ALIAS xyco_fs_uring)
-target_sources(
-  xyco_fs_uring
-  PUBLIC FILE_SET
-         fs_uring_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/fs/io_uring/mod.ccm
-         include/xyco/fs/io_uring/file.ccm)
-target_link_libraries(
-  xyco_fs_uring
-  PUBLIC xyco_fs_common
-  PRIVATE xyco::io_uring xyco::task xyco::runtime_ctx xyco::libc)
-add_library(xyco_fs_all src/fs/epoll/file.cc src/fs/io_uring/file.cc)
-add_library(xyco::fs_all ALIAS xyco_fs_all)
-target_sources(
-  xyco_fs_all
-  PUBLIC FILE_SET
-         fs_all_module
-         TYPE
-         CXX_MODULES
-         FILES
-         include/xyco/fs/mod.ccm
-         include/xyco/fs/epoll/file.ccm
-         include/xyco/fs/io_uring/file.ccm)
-target_link_libraries(
-  xyco_fs_all
-  PUBLIC xyco_fs_common
-  PRIVATE xyco::io_all xyco::task xyco::runtime_ctx xyco::libc)
+if(XYCO_IO_API STREQUAL "epoll")
+  add_library(xyco_fs src/fs/epoll/file.cc)
+  add_library(xyco::fs ALIAS xyco_fs)
+  target_sources(
+    xyco_fs
+    PUBLIC FILE_SET
+           fs_module
+           TYPE
+           CXX_MODULES
+           FILES
+           include/xyco/fs/epoll/mod.ccm
+           include/xyco/fs/epoll/file.ccm)
+  target_link_libraries(
+    xyco_fs
+    PUBLIC xyco_fs_common
+    PRIVATE xyco::io xyco::task xyco::runtime_ctx xyco::libc)
+elseif(XYCO_IO_API STREQUAL "io_uring")
+  add_library(xyco_fs src/fs/io_uring/file.cc)
+  add_library(xyco::fs ALIAS xyco_fs)
+  target_sources(
+    xyco_fs
+    PUBLIC FILE_SET
+           fs_module
+           TYPE
+           CXX_MODULES
+           FILES
+           include/xyco/fs/io_uring/mod.ccm
+           include/xyco/fs/io_uring/file.ccm)
+  target_link_libraries(
+    xyco_fs
+    PUBLIC xyco_fs_common
+    PRIVATE xyco::io xyco::task xyco::runtime_ctx xyco::libc)
+endif()
 
 add_library(xyco_time src/time/registry.cc src/time/wheel.cc src/time/clock.cc)
 add_library(xyco::time ALIAS xyco_time)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,8 @@
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
                 "CMAKE_CXX_COMPILER": "clang++",
                 "XYCO_ENABLE_LOGGING": "$env{XYCO_ENABLE_LOGGING}",
-                "XYCO_ENABLE_LINTING": "$env{XYCO_ENABLE_LINTING}"
+                "XYCO_ENABLE_LINTING": "$env{XYCO_ENABLE_LINTING}",
+                "XYCO_IO_API": "$env{XYCO_IO_API}"
             }
         },
         {
@@ -29,6 +30,26 @@
             }
         },
         {
+            "name": "io_api_epoll",
+            "displayName": "Epoll IO API Config",
+            "inherits": [
+                "root"
+            ],
+            "environment": {
+                "XYCO_IO_API": "epoll"
+            }
+        },
+        {
+            "name": "io_api_uring",
+            "displayName": "Uring IO API Config",
+            "inherits": [
+                "root"
+            ],
+            "environment": {
+                "XYCO_IO_API": "io_uring"
+            }
+        },
+        {
             "name": "enable_linting",
             "displayName": "Enable Linting Config",
             "inherits": [
@@ -39,18 +60,53 @@
             }
         },
         {
-            "name": "ci_linting_logging_off",
-            "displayName": "CI Linting with Logging Off Config",
+            "name": "epoll_ci_linting_logging_off",
+            "displayName": "CI Linting Config of Epoll targets with Logging Off",
             "inherits": [
-                "enable_linting"
+                "enable_linting",
+                "io_api_epoll"
             ]
         },
         {
-            "name": "ci_linting_logging_on",
-            "displayName": "CI Linting with Logging On Config",
+            "name": "epoll_ci_linting_logging_on",
+            "displayName": "CI Linting Config of Epoll targets with Logging On",
             "inherits": [
                 "enable_linting",
-                "enable_logging"
+                "enable_logging",
+                "io_api_epoll"
+            ]
+        },
+        {
+            "name": "io_uring_ci_linting_logging_off",
+            "displayName": "CI Linting Config of Uring targets with Logging Off",
+            "inherits": [
+                "enable_linting",
+                "io_api_uring"
+            ]
+        },
+        {
+            "name": "io_uring_ci_linting_logging_on",
+            "displayName": "CI Linting Config of Uring targets with Logging On",
+            "inherits": [
+                "enable_linting",
+                "enable_logging",
+                "io_api_uring"
+            ]
+        },
+        {
+            "name": "epoll_ci_test",
+            "displayName": "CI Test Config of Uring targets",
+            "inherits": [
+                "enable_logging",
+                "io_api_epoll"
+            ]
+        },
+        {
+            "name": "io_uring_ci_test",
+            "displayName": "CI Test Config of Uring targets",
+            "inherits": [
+                "enable_logging",
+                "io_api_uring"
             ]
         }
     ],
@@ -61,24 +117,13 @@
             "configuration": "Release"
         },
         {
-            "name": "epoll_targets",
+            "name": "all_targets",
             "hidden": true,
             "targets": [
-                "xyco_epoll_echo_server",
-                "xyco_epoll_http_server",
-                "xyco_epoll_main",
-                "xyco_test_epoll",
-                "asio_echo_server"
-            ]
-        },
-        {
-            "name": "uring_targets",
-            "hidden": true,
-            "targets": [
-                "xyco_uring_echo_server",
-                "xyco_uring_http_server",
-                "xyco_uring_main",
-                "xyco_test_uring",
+                "xyco_echo_server",
+                "xyco_http_server",
+                "xyco_main",
+                "xyco_test",
                 "asio_echo_server"
             ]
         },
@@ -86,8 +131,7 @@
             "name": "test_targets",
             "hidden": true,
             "targets": [
-                "xyco_test_epoll",
-                "xyco_test_uring"
+                "xyco_test"
             ]
         },
         {
@@ -95,41 +139,50 @@
             "displayName": "CI Linting Build of Epoll targets with Logging Off",
             "inherits": [
                 "release_mode",
-                "epoll_targets"
+                "all_targets"
             ],
-            "configurePreset": "ci_linting_logging_off"
+            "configurePreset": "epoll_ci_linting_logging_off"
         },
         {
             "name": "epoll_ci_linting_logging_on",
             "displayName": "CI Linting Build of Epoll targets with Logging On",
             "inherits": [
                 "release_mode",
-                "epoll_targets"
+                "all_targets"
             ],
-            "configurePreset": "ci_linting_logging_on"
+            "configurePreset": "epoll_ci_linting_logging_on"
         },
         {
-            "name": "uring_ci_linting_logging_off",
+            "name": "io_uring_ci_linting_logging_off",
             "displayName": "CI Linting Build of Uring targets with Logging Off",
             "inherits": [
                 "release_mode",
-                "uring_targets"
+                "all_targets"
             ],
-            "configurePreset": "ci_linting_logging_off"
+            "configurePreset": "io_uring_ci_linting_logging_off"
         },
         {
-            "name": "uring_ci_linting_logging_on",
+            "name": "io_uring_ci_linting_logging_on",
             "displayName": "CI Linting Build of Uring targets with Logging On",
             "inherits": [
                 "release_mode",
-                "uring_targets"
+                "all_targets"
             ],
-            "configurePreset": "ci_linting_logging_on"
+            "configurePreset": "io_uring_ci_linting_logging_on"
         },
         {
-            "name": "ci_test",
-            "displayName": "CI Test Build",
-            "configurePreset": "enable_logging",
+            "name": "epoll_ci_test",
+            "displayName": "CI Test Build of Epoll targets",
+            "configurePreset": "epoll_ci_test",
+            "inherits": [
+                "release_mode",
+                "test_targets"
+            ]
+        },
+        {
+            "name": "io_uring_ci_test",
+            "displayName": "CI Test Build of Uring targets",
+            "configurePreset": "io_uring_ci_test",
             "inherits": [
                 "release_mode",
                 "test_targets"
@@ -143,7 +196,7 @@
             "steps": [
                 {
                     "type": "configure",
-                    "name": "ci_linting_logging_off"
+                    "name": "epoll_ci_linting_logging_off"
                 },
                 {
                     "type": "build",
@@ -152,16 +205,16 @@
             ]
         },
         {
-            "name": "uring_ci_linting_logging_off",
+            "name": "io_uring_ci_linting_logging_off",
             "displayName": "CI Linting Workflow of Uring targets with Logging Off",
             "steps": [
                 {
                     "type": "configure",
-                    "name": "ci_linting_logging_off"
+                    "name": "io_uring_ci_linting_logging_off"
                 },
                 {
                     "type": "build",
-                    "name": "uring_ci_linting_logging_off"
+                    "name": "io_uring_ci_linting_logging_off"
                 }
             ]
         },
@@ -171,7 +224,7 @@
             "steps": [
                 {
                     "type": "configure",
-                    "name": "ci_linting_logging_on"
+                    "name": "epoll_ci_linting_logging_on"
                 },
                 {
                     "type": "build",
@@ -180,30 +233,44 @@
             ]
         },
         {
-            "name": "uring_ci_linting_logging_on",
+            "name": "io_uring_ci_linting_logging_on",
             "displayName": "CI Linting Workflow of Uring targets with Logging On",
             "steps": [
                 {
                     "type": "configure",
-                    "name": "ci_linting_logging_on"
+                    "name": "io_uring_ci_linting_logging_on"
                 },
                 {
                     "type": "build",
-                    "name": "uring_ci_linting_logging_on"
+                    "name": "io_uring_ci_linting_logging_on"
                 }
             ]
         },
         {
-            "name": "ci_test",
-            "displayName": "CI Test Workflow",
+            "name": "epoll_ci_test",
+            "displayName": "CI Test Workflow of Epoll targets",
             "steps": [
                 {
                     "type": "configure",
-                    "name": "enable_logging"
+                    "name": "epoll_ci_test"
                 },
                 {
                     "type": "build",
-                    "name": "ci_test"
+                    "name": "epoll_ci_test"
+                }
+            ]
+        },
+        {
+            "name": "io_uring_ci_test",
+            "displayName": "CI Test Workflow of Uring targets",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "io_uring_ci_test"
+                },
+                {
+                    "type": "build",
+                    "name": "io_uring_ci_test"
                 }
             ]
         }

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,12 +1,6 @@
-add_executable(xyco_epoll_echo_server echo_server.cc)
-target_link_libraries(
-  xyco_epoll_echo_server PRIVATE xyco::io_epoll xyco::net_epoll xyco::task
-                                 xyco::runtime)
-
-add_executable(xyco_uring_echo_server echo_server.cc)
-target_link_libraries(
-  xyco_uring_echo_server PRIVATE xyco::io_uring xyco::net_uring xyco::task
-                                 xyco::runtime)
+add_executable(xyco_echo_server echo_server.cc)
+target_link_libraries(xyco_echo_server PRIVATE xyco::io xyco::net xyco::task
+                                               xyco::runtime)
 
 add_executable(asio_echo_server asio_echo_server.cc)
 target_compile_definitions(asio_echo_server PUBLIC ASIO_HAS_CO_AWAIT=1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,3 @@
-add_executable(xyco_epoll_http_server http_server.cc)
-target_link_libraries(
-  xyco_epoll_http_server PRIVATE xyco::fs_epoll xyco::io_epoll xyco::net_epoll
-                                 xyco::task xyco::runtime)
-
-add_executable(xyco_uring_http_server http_server.cc)
-target_link_libraries(
-  xyco_uring_http_server PRIVATE xyco::fs_uring xyco::io_uring xyco::net_uring
-                                 xyco::task xyco::runtime)
+add_executable(xyco_http_server http_server.cc)
+target_link_libraries(xyco_http_server PRIVATE xyco::fs xyco::io xyco::net
+                                               xyco::task xyco::runtime)

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,21 @@
         };
       in
       {
-        packages.unit-test = pkgs.callPackage ./unit-test.nix {
+        packages.unit-test-epoll = pkgs.callPackage ./unit-test.nix {
           llvmPackages = llvmPackages;
           asio = asio;
           gtest = gtest;
           microsoft-gsl = microsoft-gsl;
           spdlog = spdlog;
+          IOAPI = "epoll";
+        };
+        packages.unit-test-uring = pkgs.callPackage ./unit-test.nix {
+          llvmPackages = llvmPackages;
+          asio = asio;
+          gtest = gtest;
+          microsoft-gsl = microsoft-gsl;
+          spdlog = spdlog;
+          IOAPI = "io_uring";
         };
         packages.lint-epoll = pkgs.callPackage ./lint.nix {
           llvmPackages = llvmPackages;
@@ -44,7 +53,7 @@
           gtest = gtest;
           microsoft-gsl = microsoft-gsl;
           spdlog = spdlog;
-          IOAPI = "uring";
+          IOAPI = "io_uring";
         };
       });
 }

--- a/include/xyco/fs/mod.ccm
+++ b/include/xyco/fs/mod.ccm
@@ -1,5 +1,0 @@
-export module xyco.fs;
-
-export import xyco.fs.epoll;
-export import xyco.fs.uring;
-export import xyco.fs.common;

--- a/include/xyco/io/mod.ccm
+++ b/include/xyco/io/mod.ccm
@@ -1,5 +1,0 @@
-export module xyco.io;
-
-export import xyco.io.epoll;
-export import xyco.io.uring;
-export import xyco.io.common;

--- a/include/xyco/net/mod.ccm
+++ b/include/xyco/net/mod.ccm
@@ -1,5 +1,0 @@
-export module xyco.net;
-
-export import xyco.net.epoll;
-export import xyco.net.uring;
-export import xyco.net.common;

--- a/lint.nix
+++ b/lint.nix
@@ -34,8 +34,8 @@ llvmPackages.libcxxStdenv.mkDerivation {
   configurePhase = ''
     runHook preConfigure
 
-    cmake --preset ci_linting_logging_off
-    cmake --preset ci_linting_logging_on
+    cmake --preset ${IOAPI}_ci_linting_logging_off
+    cmake --preset ${IOAPI}_ci_linting_logging_on
 
     runHook postConfigure
   '';
@@ -58,11 +58,11 @@ llvmPackages.libcxxStdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    MAIN_BIN_PATTERN=build/ci_linting_{}/xyco_${IOAPI}_main
-    UT_BIN_PATTERN=build/ci_linting_{}/tests/xyco_test_${IOAPI}
-    EXAMPLE_BIN_PATTERN=build/ci_linting_{}/examples/xyco_${IOAPI}_http_server
-    BENCHMARK_BIN_PATTERN=build/ci_linting_{}/benchmark/xyco_${IOAPI}_echo_server
-    BENCHMARK_ASIO_BIN_PATTERN=build/ci_linting_{}/benchmark/asio_echo_server
+    MAIN_BIN_PATTERN=build/${IOAPI}_ci_linting_{}/xyco_main
+    UT_BIN_PATTERN=build/${IOAPI}_ci_linting_{}/tests/xyco_test
+    EXAMPLE_BIN_PATTERN=build/${IOAPI}_ci_linting_{}/examples/xyco_http_server
+    BENCHMARK_BIN_PATTERN=build/${IOAPI}_ci_linting_{}/benchmark/xyco_echo_server
+    BENCHMARK_ASIO_BIN_PATTERN=build/${IOAPI}_ci_linting_{}/benchmark/asio_echo_server
 
     mkdir -p $out/logging_off $out/logging_on
     MAIN_BIN=$(echo $MAIN_BIN_PATTERN | sed -e "s/{}/logging_off/g")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,24 +3,23 @@ include(GoogleTest)
 set(CMAKE_CXX_FLAGS "-fprofile-instr-generate -fcoverage-mapping"
                     ${CMAKE_CXX_FLAGS})
 
-add_library(xyco_test_common_utils)
-target_sources(xyco_test_common_utils PUBLIC FILE_SET common_utils_module TYPE
-                                             CXX_MODULES FILES common/utils.ccm)
-target_include_directories(xyco_test_common_utils PUBLIC common)
-target_link_libraries(xyco_test_common_utils PUBLIC xyco::runtime xyco::task
-                                                    xyco::time xyco::sync gtest)
-
-add_library(xyco_test_epoll_utils common/utils.cc)
+add_library(xyco_test_utils common/utils.cc)
+target_sources(xyco_test_utils PUBLIC FILE_SET utils_module TYPE CXX_MODULES
+                                      FILES common/utils.ccm)
+target_include_directories(xyco_test_utils PUBLIC common)
 target_link_libraries(
-  xyco_test_epoll_utils PUBLIC xyco_test_common_utils xyco::io_epoll
-                               xyco::fs_epoll xyco::net_epoll)
-add_library(xyco_test_uring_utils common/utils.cc)
-target_link_libraries(
-  xyco_test_uring_utils PUBLIC xyco_test_common_utils xyco::io_uring
-                               xyco::fs_uring xyco::net_uring)
+  xyco_test_utils
+  PUBLIC xyco::runtime
+         xyco::sync
+         xyco::task
+         xyco::time
+         xyco::fs
+         xyco::net
+         xyco::io
+         gtest)
 
 add_executable(
-  xyco_test_epoll
+  xyco_test
   main.cc
   fs/file.cc
   io/buffer.cc
@@ -36,26 +35,6 @@ add_executable(
   time/clock.cc
   time/sleep.cc
   time/timeout.cc
-  utils/epoll/fmt_test.cc
+  utils/${XYCO_IO_API}/fmt_test.cc
   utils/fmt_test.cc)
-target_link_libraries(xyco_test_epoll PRIVATE xyco_test_epoll_utils)
-add_executable(
-  xyco_test_uring
-  main.cc
-  fs/file.cc
-  io/buffer.cc
-  net/socket.cc
-  net/tcp.cc
-  runtime/future.cc
-  runtime/join.cc
-  runtime/runtime.cc
-  runtime/select.cc
-  sync/mpsc.cc
-  sync/oneshot.cc
-  task/blocking_task.cc
-  time/clock.cc
-  time/sleep.cc
-  time/timeout.cc
-  utils/io_uring/fmt_test.cc
-  utils/fmt_test.cc)
-target_link_libraries(xyco_test_uring PRIVATE xyco_test_uring_utils)
+target_link_libraries(xyco_test PRIVATE xyco_test_utils)


### PR DESCRIPTION
Deprecate io related `all` targets. It's almost useless in actual application. And its deprecation clears the barrier to unify the build interface for both epoll and io uring api.