### PR TITLE
[Build] distribute library as source code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,13 +24,11 @@
       in
       {
         packages.lib-epoll = pkgs.callPackage ./lib.nix {
-          llvmPackages = llvmPackages;
           microsoft-gsl = microsoft-gsl;
           spdlog = spdlog;
           IOAPI = "epoll";
         };
         packages.lib-uring = pkgs.callPackage ./lib.nix {
-          llvmPackages = llvmPackages;
           microsoft-gsl = microsoft-gsl;
           spdlog = spdlog;
           IOAPI = "io_uring";


### PR DESCRIPTION
Let dependents use it as flake input directly without fetching the repo manually.